### PR TITLE
feat : 유저끼리의 팔로우 기능 구현 및 유저정보 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'
-    // runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/finalproject/manitoone/controller/FollowController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/FollowController.java
@@ -1,0 +1,28 @@
+package com.finalproject.manitoone.controller;
+
+import com.finalproject.manitoone.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follow")
+public class FollowController {
+
+  private final FollowService followService;
+
+  @GetMapping("/{myId}/{targetId}")
+  public ResponseEntity<Void> followUnfollow(@PathVariable Long myId, @PathVariable Long targetId) {
+    // TODO: 내 유저의 ID를 추후 세션에서 받아오도록 변경 필요
+    if (followService.toggleFollow(myId, targetId)) {
+      return ResponseEntity.status(HttpStatus.CREATED).build();
+    } else {
+      return ResponseEntity.status(HttpStatus.OK).build();
+    }
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/controller/UserController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.finalproject.manitoone.controller;
+
+import com.finalproject.manitoone.dto.user.UserInformationResponseDto;
+import com.finalproject.manitoone.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+
+  private final UserService userService;
+
+  @GetMapping("/{nickname}")
+  public ResponseEntity<UserInformationResponseDto> getUserInformation(@PathVariable String nickname) {
+    return ResponseEntity.ok(userService.getUserByNickname(nickname));
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/domain/Follow.java
+++ b/src/main/java/com/finalproject/manitoone/domain/Follow.java
@@ -1,0 +1,36 @@
+package com.finalproject.manitoone.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "follow")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Follow {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "follow_id", nullable = false)
+  private Long followId;
+
+  @ManyToOne
+  @JoinColumn(name = "follower_id", nullable = false)
+  private User follower;
+
+  @ManyToOne
+  @JoinColumn(name = "following_id", nullable = false)
+  private User following;
+}

--- a/src/main/java/com/finalproject/manitoone/domain/User.java
+++ b/src/main/java/com/finalproject/manitoone/domain/User.java
@@ -1,0 +1,81 @@
+package com.finalproject.manitoone.domain;
+
+import com.finalproject.manitoone.dto.user.UserInformationResponseDto;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long userId;
+
+  @Column(name = "email", nullable = false, length = 50, unique = true)
+  private String email;
+
+  @Column(name = "password", nullable = false, length = 200)
+  private String password;
+
+  @Column(name = "name", nullable = false, length = 10)
+  private String name;
+
+  @Column(name = "nickname", nullable = false, length = 10, unique = true)
+  private String nickname;
+
+  @Column(name = "birth", nullable = false)
+  private LocalDateTime birth;
+
+  @Column(name = "introduce", nullable = false, length = 100, columnDefinition = "default 기본소개를 입력해주세요.")
+  @Builder.Default
+  private String introduce = "기본소개를 입력해주세요.";
+
+  @Column(name = "profile_image", nullable = false, columnDefinition = "text default /img/defaultProfile.png")
+  @Builder.Default
+  private String profileImage = "/img/defaultProfile.png";
+
+  @Column(name = "status", nullable = false, columnDefinition = "default 1 comment '1. 활동\n2. 정지\n3. 탈퇴'")
+  @Builder.Default
+  private Integer status = 1;
+
+  @Column(name = "is_manito_received", nullable = false, columnDefinition = "tinyint default 1 comment '0. 수신거부\n1. 수신'")
+  @Builder.Default
+  private Boolean isManitoReceived = true;
+
+  @Column(name = "role", nullable = false, length = 50, columnDefinition = "varchar(50) default 'ROLE_USER'")
+  @Builder.Default
+  private String role = "ROLE_USER";
+
+  @Column(name = "unbanned_at")
+  private LocalDateTime unbannedAt;
+
+  @Column(name = "created_at", nullable = false, columnDefinition = "timestamp default now()")
+  @Builder.Default
+  private LocalDateTime createdAt = LocalDateTime.now();
+
+  public UserInformationResponseDto toUserInformationDto() {
+    return new UserInformationResponseDto(
+        this.name,
+        this.nickname,
+        this.introduce,
+        this.profileImage,
+        null,
+        null
+    );
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/dto/follow/FollowRequestDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/follow/FollowRequestDto.java
@@ -1,0 +1,13 @@
+package com.finalproject.manitoone.dto.follow;
+
+import com.finalproject.manitoone.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowRequestDto {
+
+  private User follower;
+  private User following;
+}

--- a/src/main/java/com/finalproject/manitoone/dto/follow/FollowResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/follow/FollowResponseDto.java
@@ -1,0 +1,14 @@
+package com.finalproject.manitoone.dto.follow;
+
+import com.finalproject.manitoone.domain.Follow;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowResponseDto {
+
+  private List<Follow> followers;
+  private List<Follow> followings;
+}

--- a/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
@@ -14,7 +14,6 @@ public class UserInformationResponseDto {
   private String nickname;
   private String introduce;
   private String profileImage;
-  private Integer status;
   private List<UserInformationResponseDto> followers;
   private List<UserInformationResponseDto> followings;
 

--- a/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
@@ -1,0 +1,24 @@
+package com.finalproject.manitoone.dto.user;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserInformationResponseDto {
+
+  private String name;
+  private String nickname;
+  private String introduce;
+  private String profileImage;
+  private Integer status;
+  private List<UserInformationResponseDto> followers;
+  private List<UserInformationResponseDto> followings;
+
+  public void setFollow(List<UserInformationResponseDto> followers,
+      List<UserInformationResponseDto> followings) {
+    this.followers = followers;
+    this.followings = followings;
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
@@ -1,11 +1,13 @@
 package com.finalproject.manitoone.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserInformationResponseDto {
 
   private String name;
@@ -16,8 +18,7 @@ public class UserInformationResponseDto {
   private List<UserInformationResponseDto> followers;
   private List<UserInformationResponseDto> followings;
 
-  public void setFollow(List<UserInformationResponseDto> followers,
-      List<UserInformationResponseDto> followings) {
+  public void setFollow(List<UserInformationResponseDto> followers, List<UserInformationResponseDto> followings) {
     this.followers = followers;
     this.followings = followings;
   }

--- a/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
@@ -18,7 +18,8 @@ public class UserInformationResponseDto {
   private List<UserInformationResponseDto> followers;
   private List<UserInformationResponseDto> followings;
 
-  public void setFollow(List<UserInformationResponseDto> followers, List<UserInformationResponseDto> followings) {
+  public void setFollow(List<UserInformationResponseDto> followers,
+      List<UserInformationResponseDto> followings) {
     this.followers = followers;
     this.followings = followings;
   }

--- a/src/main/java/com/finalproject/manitoone/repository/FollowRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/FollowRepository.java
@@ -1,0 +1,15 @@
+package com.finalproject.manitoone.repository;
+
+import com.finalproject.manitoone.domain.Follow;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+  Optional<List<Follow>> findAllByFollower_UserId(Long userId);
+
+  Optional<List<Follow>> findAllByFollowing_UserId(Long userId);
+}

--- a/src/main/java/com/finalproject/manitoone/repository/FollowRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/FollowRepository.java
@@ -12,4 +12,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
   Optional<List<Follow>> findAllByFollower_UserId(Long userId);
 
   Optional<List<Follow>> findAllByFollowing_UserId(Long userId);
+
+  Optional<Follow> findByFollower_UserIdAndFollowing_UserId(Long followerId, Long followingId);
 }

--- a/src/main/java/com/finalproject/manitoone/repository/UserRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.finalproject.manitoone.repository;
+
+import com.finalproject.manitoone.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findUserByNickname(String nickname);
+}

--- a/src/main/java/com/finalproject/manitoone/service/FollowService.java
+++ b/src/main/java/com/finalproject/manitoone/service/FollowService.java
@@ -1,0 +1,42 @@
+package com.finalproject.manitoone.service;
+
+import com.finalproject.manitoone.domain.Follow;
+import com.finalproject.manitoone.domain.User;
+import com.finalproject.manitoone.dto.follow.FollowRequestDto;
+import com.finalproject.manitoone.repository.FollowRepository;
+import com.finalproject.manitoone.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+  private final FollowRepository followRepository;
+  private final UserRepository userRepository;
+
+  public Boolean toggleFollow(Long userId, Long targetUserId) {
+
+    if (userId.equals(targetUserId)) {
+      throw new IllegalArgumentException("자시 자신은 팔로우 할 수 없습니다.");
+    }
+
+    Optional<Follow> follow = followRepository.findByFollower_UserIdAndFollowing_UserId(userId,
+        targetUserId);
+
+    if (follow.isPresent()) {
+      followRepository.delete(follow.get());
+      return Boolean.FALSE;
+    } else {
+      // TODO: 재사용 가능해 보이는 메시지를 Enum 클래스에 정의하기
+      User my = userRepository.findById(userId)
+          .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 유저를 찾을 수 없습니다."));
+      User target = userRepository.findById(targetUserId)
+          .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 유저를 찾을 수 없습니다."));
+      Follow newFollow = new Follow(null, my, target);
+      followRepository.save(newFollow);
+      return Boolean.TRUE;
+    }
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/service/FollowService.java
+++ b/src/main/java/com/finalproject/manitoone/service/FollowService.java
@@ -2,7 +2,6 @@ package com.finalproject.manitoone.service;
 
 import com.finalproject.manitoone.domain.Follow;
 import com.finalproject.manitoone.domain.User;
-import com.finalproject.manitoone.dto.follow.FollowRequestDto;
 import com.finalproject.manitoone.repository.FollowRepository;
 import com.finalproject.manitoone.repository.UserRepository;
 import java.util.Optional;

--- a/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
@@ -27,7 +27,7 @@ public class UserAuthService {
     }
 
     // 닉네임 중복 체크
-    Optional<User> existUserByNickname = userRepository.findByNickname(userSignUpDTO.getNickname());
+    Optional<User> existUserByNickname = userRepository.findUserByNickname(userSignUpDTO.getNickname());
     if (existUserByNickname.isPresent()) {
       return "닉네임이 이미 사용중입니다.";
     }

--- a/src/main/java/com/finalproject/manitoone/service/UserService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserService.java
@@ -1,0 +1,43 @@
+package com.finalproject.manitoone.service;
+
+import com.finalproject.manitoone.domain.Follow;
+import com.finalproject.manitoone.domain.User;
+import com.finalproject.manitoone.dto.user.UserInformationResponseDto;
+import com.finalproject.manitoone.repository.FollowRepository;
+import com.finalproject.manitoone.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final FollowRepository followRepository;
+
+  public UserInformationResponseDto getUserByNickname(String nickname) {
+    //TODO: 재사용 가능한 메시지들은 Enum으로 빼서 처리하기.
+    User user = userRepository.findUserByNickname(nickname)
+        .orElseThrow(() -> new IllegalArgumentException("해당하는 유저의 닉네임을 찾을 수 없습니다."));
+    UserInformationResponseDto userInformation = userRepository.findUserByNickname(nickname)
+        .orElseThrow(() -> new IllegalArgumentException("해당하는 유저의 닉네임을 찾을 수 없습니다."))
+        .toUserInformationDto();
+
+    List<Follow> followersList = followRepository.findAllByFollower_UserId(user.getUserId())
+        .orElseThrow(() -> new IllegalArgumentException("팔로워 정보를 가져오는데에 실패했습니다."));
+    List<UserInformationResponseDto> followers = followersList.stream()
+        .map(follow -> follow.getFollowing().toUserInformationDto())
+        .toList();
+
+    List<Follow> followingsList = followRepository.findAllByFollowing_UserId(user.getUserId())
+        .orElseThrow(() -> new IllegalArgumentException("팔로잉 정보를 가져오는데에 실패했습니다."));
+    List<UserInformationResponseDto> followings = followingsList.stream()
+        .map(follow -> follow.getFollower().toUserInformationDto())
+        .toList();
+
+    userInformation.setFollow(followers, followings);
+
+    return userInformation;
+  }
+}


### PR DESCRIPTION
## :mag_right: 작업 내용
- 유저끼리의 팔로우 기능을 구현했습니다.
- 해당 닉네임을 가진 유저의 정보를 받아올 수 있는 api를 구현했습니다.

## ⚫️이미지 첨부
![image](https://github.com/user-attachments/assets/c71e44eb-f926-4aee-9a0d-abc8df8811ee)
![image](https://github.com/user-attachments/assets/186656f5-f916-4959-8aea-86d93bb2c0b9)

## :heavy_plus_sign: 이슈 링크
- [#19 ](https://github.com/kkb00714/ManiToOne/issues/19)

## 첨언
~~각 유저의 정보에 status는 필요없어 보입니다.~~
수정되었습니다.
