### PR TITLE
feat : 로그인 및 비밀번호 찾기 구현

### DIFF
--- a/src/main/java/com/finalproject/manitoone/config/SecurityConfig.java
+++ b/src/main/java/com/finalproject/manitoone/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.finalproject.manitoone.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -12,13 +13,17 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
   @Bean
-  protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http
-        .csrf(csrf -> csrf.disable())
-        .authorizeRequests()
-//                .antMatchers("/admin/"**).hasRole("ADMIN") // 어드민 페이지 생성 및 롤 생성 시 활성화
-        .anyRequest().permitAll();
-    return http.build();
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+        .authorizeHttpRequests(custom -> custom
+            // .antMatchers("/admin/"**).hasRole("ADMIN") // 어드민 페이지 생성 및 롤 생성 시 활성화
+            .anyRequest().permitAll()
+        )
+//        .formLogin(custom -> custom
+//            .loginPage("/login")
+//            )
+        .csrf(AbstractHttpConfigurer::disable)
+        .build();
   }
 
   @Bean

--- a/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
+++ b/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
@@ -11,7 +11,14 @@ public enum IllegalActionMessages {
   CANNOT_FIND_USER_BY_GIVEN_NICKNAME("해당하는 유저의 닉네임을 찾을 수 없습니다."),
   CANNOT_GET_FOLLOWERS("팔로워 정보를 가져오는 중 문제가 발생했습니다."),
   CANNOT_GET_FOLLOWING("팔로잉 정보를 가져오는 중 문제가 발생했습니다."),
-  CANNOT_FOLLOW_YOURSELF("자기 자신은 팔로우 할 수 없습니다.");
+  CANNOT_FOLLOW_YOURSELF("자기 자신은 팔로우 할 수 없습니다."),
+
+  // Auth
+  CANNOT_USE_EMAIL("이미 사용 중인 이메일입니다"),
+  CANNOT_USE_NICKNAME("이미 사용 중인 닉네임입니다"),
+  CANNOT_VERIFY_EMAIL("이메일 인증에 실패했습니다."),
+  CANNOT_FIND_EMAIL_OR_PASSWORD("이메일 및 비밀번호가 일치하지 않습니다."),
+  CANNOT_SUCCESS_LOGIN("로그인에 실패했습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
+++ b/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
@@ -14,6 +14,7 @@ public enum IllegalActionMessages {
   CANNOT_FOLLOW_YOURSELF("자기 자신은 팔로우 할 수 없습니다."),
 
   // Auth
+  CANNOT_FIND_ANY_USER("해당하는 유저를 찾을 수 없습니다."),
   CANNOT_USE_EMAIL("이미 사용 중인 이메일입니다"),
   CANNOT_USE_NICKNAME("이미 사용 중인 닉네임입니다"),
   CANNOT_VERIFY_EMAIL("이메일 인증에 실패했습니다."),

--- a/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
+++ b/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
@@ -17,6 +17,7 @@ public enum IllegalActionMessages {
   CANNOT_USE_EMAIL("이미 사용 중인 이메일입니다"),
   CANNOT_USE_NICKNAME("이미 사용 중인 닉네임입니다"),
   CANNOT_VERIFY_EMAIL("이메일 인증에 실패했습니다."),
+  CANNOT_VERIFY_EMAIL_NUMBER("이메일 인증번호가 일치하지 않습니다."),
   CANNOT_FIND_EMAIL_OR_PASSWORD("이메일 및 비밀번호가 일치하지 않습니다."),
   CANNOT_SUCCESS_LOGIN("로그인에 실패했습니다.");
 

--- a/src/main/java/com/finalproject/manitoone/controller/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/UserAuthController.java
@@ -1,11 +1,15 @@
 package com.finalproject.manitoone.controller;
 
+import com.finalproject.manitoone.domain.dto.UserLoginRequestDto;
+import com.finalproject.manitoone.domain.dto.UserLoginResponseDto;
 import com.finalproject.manitoone.domain.dto.UserSignUpDTO;
 import com.finalproject.manitoone.service.UserAuthService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +33,32 @@ public class UserAuthController {
     } catch (IllegalArgumentException e) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
+  }
+
+  @PostMapping("/local-login")
+  public ResponseEntity<?> signIn(
+      @RequestBody UserLoginRequestDto userLoginRequestDto,
+      HttpSession session
+  ) {
+    try {
+      UserLoginResponseDto responseDto = userAuthService.localLogin(
+          userLoginRequestDto.getEmail(),
+          userLoginRequestDto.getPassword()
+      );
+      session.setAttribute("user", responseDto);
+      return ResponseEntity.ok(responseDto);
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  // 테스트용 - 현재 로그인된 유저 정보 반환
+  @GetMapping("/current-user")
+  public ResponseEntity<?> getSessionInfo(HttpSession session) {
+    UserLoginResponseDto loginUser = (UserLoginResponseDto) session.getAttribute("user");
+    if (loginUser == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인된 유저 정보가 없습니다.");
+    }
+    return ResponseEntity.ok(loginUser);
   }
 }

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -1,4 +1,4 @@
-package com.finalproject.manitoone.controller;
+package com.finalproject.manitoone.controller.api;
 
 import com.finalproject.manitoone.domain.dto.UserLoginRequestDto;
 import com.finalproject.manitoone.domain.dto.UserLoginResponseDto;

--- a/src/main/java/com/finalproject/manitoone/controller/view/MailController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/MailController.java
@@ -22,7 +22,7 @@ public class MailController {
   public ResponseEntity<String> mailSend(@RequestBody Map<String, String> request) {
     String email = request.get("email");
     try {
-      mailService.sendMail(email);
+      mailService.verifyEmail(email);
       return ResponseEntity.ok("인증 메일이 전송되었습니다.");
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/finalproject/manitoone/controller/view/MailController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/MailController.java
@@ -43,4 +43,21 @@ public class MailController {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
   }
+
+  // 비밀번호 초기화 메일 발송
+  @PostMapping("/password-reset")
+  public ResponseEntity<String> resetPassword(@RequestBody Map<String, String> request) {
+    String email = request.get("email");
+    String name = request.get("name");
+
+    try {
+      mailService.findPassword(email, name);
+      return ResponseEntity.ok("임시 비밀번호가 이메일로 전송되었습니다.");
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body("비밀번호 초기화 실패: " + e.getMessage());
+    }
+  }
 }

--- a/src/main/java/com/finalproject/manitoone/controller/view/UserAuthViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/UserAuthViewController.java
@@ -1,0 +1,18 @@
+package com.finalproject.manitoone.controller.view;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserAuthViewController {
+
+  @GetMapping("/register")
+  public String getSignUpPage() {
+    return "/pages/auth/sign-up";
+  }
+
+  @GetMapping("/login")
+  public String getSignInPage() {
+    return "/pages/auth/sign-in";
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/controller/view/UserAuthViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/UserAuthViewController.java
@@ -1,11 +1,12 @@
 package com.finalproject.manitoone.controller.view;
 
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
-@RestController
+@Controller
 public class UserAuthViewController {
 
+  // TODO 회원가입 시 이메일 인증을 우선적으로 해야 함.
   @GetMapping("/register")
   public String getSignUpPage() {
     return "/pages/auth/sign-up";

--- a/src/main/java/com/finalproject/manitoone/domain/User.java
+++ b/src/main/java/com/finalproject/manitoone/domain/User.java
@@ -67,4 +67,8 @@ public class User {
   @Column(name = "created_at", nullable = false, columnDefinition = "timestamp default now()")
   @Builder.Default
   private LocalDateTime createdAt = LocalDateTime.now();
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
 }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginRequestDto.java
@@ -1,0 +1,14 @@
+package com.finalproject.manitoone.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserLoginRequestDto {
+
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginResponseDto.java
@@ -1,0 +1,28 @@
+package com.finalproject.manitoone.domain.dto;
+
+import com.finalproject.manitoone.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserLoginResponseDto {
+
+  private String email;
+  private String name;
+  private String nickname;
+  private String profileImage;
+  private String introduce;
+
+  public UserLoginResponseDto(User user) {
+    this.email = user.getEmail();
+    this.name = user.getName();
+    this.nickname = user.getNickname();
+    this.profileImage = user.getProfileImage();
+    this.introduce = user.getIntroduce();
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/repository/UserRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/UserRepository.java
@@ -11,4 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findUserByNickname(String nickname);
 
   Optional<User> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/finalproject/manitoone/service/MailService.java
+++ b/src/main/java/com/finalproject/manitoone/service/MailService.java
@@ -17,7 +17,6 @@ public class MailService {
 
   private final UserRepository userRepository;
   private final JavaMailSender javaMailSender;
-  // TODO 푸시할 때 실제 메일 숨기기
   private static final String senderEmail = "kkb00714@gmail.com";
 
   // 이메일 인증 여부 저장
@@ -48,7 +47,7 @@ public class MailService {
     return message;
   }
 
-  public void sendMail(String email) {
+  public void verifyEmail(String email) {
     // 1. 중복 이메일 체크
     Optional<User> existUserByEmail = userRepository.findByEmail(email);
     if (existUserByEmail.isPresent()) {

--- a/src/main/java/com/finalproject/manitoone/service/MailService.java
+++ b/src/main/java/com/finalproject/manitoone/service/MailService.java
@@ -1,13 +1,16 @@
 package com.finalproject.manitoone.service;
 
 import com.finalproject.manitoone.constants.IllegalActionMessages;
+import com.finalproject.manitoone.domain.User;
 import com.finalproject.manitoone.repository.UserRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import java.security.SecureRandom;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,6 +19,7 @@ public class MailService {
 
   private final UserRepository userRepository;
   private final JavaMailSender javaMailSender;
+  private final PasswordEncoder passwordEncoder;
   private static final String senderEmail = "kkb00714@gmail.com";
 
   // 이메일 인증 여부 저장
@@ -84,5 +88,54 @@ public class MailService {
   // 인증 이메일 제거 (회원가입 후 정리)
   public void removeVerifiedEmail(String email) {
     verifiedEmailMap.remove(email);
+  }
+
+  // 랜덤 비밀번호 생성 메서드
+  private String generateRandomPassword(int length) {
+    String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+    StringBuilder password = new StringBuilder();
+    SecureRandom random = new SecureRandom();
+
+    for (int i = 0; i < length; i++) {
+      int index = random.nextInt(characters.length());
+      password.append(characters.charAt(index));
+    }
+    return password.toString();
+  }
+
+  // 비밀번호 초기화 메서드
+  public void findPassword(String email, String name) {
+
+    // 1. 이메일로 사용자 검색 및 이름 일치 여부 확인
+    User user = userRepository.findByEmail(email)
+        .filter(u -> u.getName().equals(name))
+        .orElseThrow(() ->
+            new IllegalArgumentException(IllegalActionMessages.CANNOT_FIND_ANY_USER.getMessage()));
+
+    // 2. 임시 비밀번호 생성
+    String temporaryPassword = generateRandomPassword(12);
+
+    // 3. 비밀번호 암호화 및 업데이트
+    String encodedPassword = passwordEncoder.encode(temporaryPassword);
+    user.setPassword(encodedPassword);
+    userRepository.save(user);
+
+    // 4. 이메일 발송
+    MimeMessage message = javaMailSender.createMimeMessage();
+    try {
+      message.setFrom(senderEmail);
+      message.setRecipients(MimeMessage.RecipientType.TO, email);
+      message.setSubject("비밀번호 초기화 안내");
+      String body = "<h3>안녕하세요,</h3>";
+      body += "<p>임시 비밀번호는 다음과 같습니다:</p>";
+      body += "<h2>" + temporaryPassword + "</h2>";
+      body += "<p>로그인 후 즉시 비밀번호를 변경하시기 바랍니다.</p>";
+      message.setText(body, "UTF-8", "html");
+      javaMailSender.send(message);
+    } catch (MessagingException e) {
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_VERIFY_EMAIL.getMessage()
+      );
+    }
   }
 }

--- a/src/main/java/com/finalproject/manitoone/service/MailService.java
+++ b/src/main/java/com/finalproject/manitoone/service/MailService.java
@@ -1,11 +1,9 @@
 package com.finalproject.manitoone.service;
 
-import com.finalproject.manitoone.domain.User;
 import com.finalproject.manitoone.repository.UserRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -49,8 +47,8 @@ public class MailService {
 
   public void verifyEmail(String email) {
     // 1. 중복 이메일 체크
-    Optional<User> existUserByEmail = userRepository.findByEmail(email);
-    if (existUserByEmail.isPresent()) {
+    boolean existUserByEmail = userRepository.existsByEmail(email);
+    if (existUserByEmail) {
       throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
     }
 

--- a/src/main/java/com/finalproject/manitoone/service/MailService.java
+++ b/src/main/java/com/finalproject/manitoone/service/MailService.java
@@ -1,5 +1,6 @@
 package com.finalproject.manitoone.service;
 
+import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.repository.UserRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -40,7 +41,9 @@ public class MailService {
       body += "<h3>" + "감사합니다." + "</h3>";
       message.setText(body, "UTF-8", "html");
     } catch (MessagingException e) {
-      throw new RuntimeException("이메일 인증이 완료되지 않았습니다.");
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_VERIFY_EMAIL_NUMBER.getMessage()
+      );
     }
     return message;
   }
@@ -49,7 +52,9 @@ public class MailService {
     // 1. 중복 이메일 체크
     boolean existUserByEmail = userRepository.existsByEmail(email);
     if (existUserByEmail) {
-      throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_USE_EMAIL.getMessage()
+      );
     }
 
     int number = createNumber();
@@ -62,7 +67,9 @@ public class MailService {
   public void verifyNumber(String email, int inputNumber) {
     Integer savedNumber = verificationMap.get(email);
     if (savedNumber == null || savedNumber != inputNumber) {
-      throw new IllegalArgumentException("인증번호가 올바르지 않습니다.");
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_VERIFY_EMAIL_NUMBER.getMessage()
+      );
     }
     // 인증 완료된 이메일 저장
     verifiedEmailMap.put(email, true);

--- a/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
@@ -24,14 +24,18 @@ public class UserAuthService {
 
     // 1. 이메일 인증 여부 확인
     if (!mailService.isVerified(email)) {
-      throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다.");
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_VERIFY_EMAIL.getMessage()
+      );
     }
 
     // 2. 닉네임 중복 체크
     boolean existUserByNickname = userRepository.existsByNickname(
         userSignUpDTO.getNickname());
     if (existUserByNickname) {
-      throw new IllegalArgumentException("닉네임이 이미 사용중입니다.");
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_USE_NICKNAME.getMessage()
+      );
     }
 
     // 3. 비밀번호 암호화 후 회원 저장

--- a/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
@@ -4,7 +4,6 @@ import com.finalproject.manitoone.domain.User;
 import com.finalproject.manitoone.domain.dto.UserSignUpDTO;
 import com.finalproject.manitoone.repository.UserRepository;
 import jakarta.transaction.Transactional;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -27,9 +26,9 @@ public class UserAuthService {
     }
 
     // 2. 닉네임 중복 체크
-    Optional<User> existUserByNickname = userRepository.findUserByNickname(
+    boolean existUserByNickname = userRepository.existsByNickname(
         userSignUpDTO.getNickname());
-    if (existUserByNickname.isPresent()) {
+    if (existUserByNickname) {
       throw new IllegalArgumentException("닉네임이 이미 사용중입니다.");
     }
 

--- a/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
@@ -1,6 +1,8 @@
 package com.finalproject.manitoone.service;
 
+import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.domain.User;
+import com.finalproject.manitoone.domain.dto.UserLoginResponseDto;
 import com.finalproject.manitoone.domain.dto.UserSignUpDTO;
 import com.finalproject.manitoone.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -40,5 +42,23 @@ public class UserAuthService {
     // 4. 인증 완료 상태 제거
     mailService.removeVerifiedEmail(email);
     return "회원가입이 완료됐습니다";
+  }
+
+  // 로그인 서비스
+  @Transactional
+  public UserLoginResponseDto localLogin(String email, String password) {
+    // 1. 이메일로 사용자 조회
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new IllegalArgumentException(
+            IllegalActionMessages.CANNOT_FIND_EMAIL_OR_PASSWORD.getMessage()));
+
+    // 2. 비밀번호 검증
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new IllegalArgumentException(
+          IllegalActionMessages.CANNOT_FIND_EMAIL_OR_PASSWORD.getMessage());
+    }
+
+    // 3. 로그인 성공 시 사용자 정보 반환 (세션에 저장)
+    return new UserLoginResponseDto(user);
   }
 }


### PR DESCRIPTION
## :mag_right: 작업 내용
- 닉네임, 이메일 중복체크 메서드를 boolean으로 변경했습니다. (검색 속도 상승 및 복잡도 최소화)
- IllegalArgumentException으로 에러 메시지를 띄웠던 부분들을 전부 IllegalActionMessage로 변경했습니다.
- 로그인 시 세션에 로그인 한 유저의 email, name, nickname, profileImage, introdce를 저장합니다.
- Spring-Security의 구조를 변경했습니다. (authorizeRequests()  -> authorizeHttpRequests로 변경)
- 비밀번호 찾기 시, email과 name을 입력하여 현재 존재하는 유저일 때에만 비밀번호 초기화 메일을 전송합니다.


## ⚫️이미지 첨부


## :heavy_plus_sign: 이슈 링크

- [#39] 
- [#46]
- [#49] 