### PR TITLE
refactor : 마이페이지, 타 유저 페이지 작업 및 DTO 변동

### DIFF
--- a/src/main/java/com/finalproject/manitoone/controller/FollowController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/FollowController.java
@@ -16,10 +16,11 @@ public class FollowController {
 
   private final FollowService followService;
 
-  @GetMapping("/{myId}/{targetId}")
-  public ResponseEntity<Void> followUnfollow(@PathVariable Long myId, @PathVariable Long targetId) {
+  @GetMapping("/{myNickName}/{targetNickName}")
+  public ResponseEntity<Void> followUnfollow(@PathVariable String myNickName,
+      @PathVariable String targetNickName) {
     // TODO: 내 유저의 ID를 추후 세션에서 받아오도록 변경 필요
-    if (followService.toggleFollow(myId, targetId)) {
+    if (Boolean.TRUE.equals(followService.toggleFollow(myNickName, targetNickName))) {
       return ResponseEntity.status(HttpStatus.CREATED).build();
     } else {
       return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/com/finalproject/manitoone/controller/PostController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/PostController.java
@@ -47,7 +47,7 @@ public class PostController {
 
   @GetMapping("/{nickName}/liked")
   public ResponseEntity<List<PostViewResponseDto>> getLikedPostsByUserId(@PathVariable String nickName,
-      @PageableDefault(sort = "postId", direction = Sort.Direction.DESC) Pageable pageable) {
+      @PageableDefault(direction = Sort.Direction.DESC) Pageable pageable) {
     return ResponseEntity.ok(postService.getLikePostByNickName(nickName, pageable));
   }
 

--- a/src/main/java/com/finalproject/manitoone/controller/ProfileViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/ProfileViewController.java
@@ -1,0 +1,23 @@
+package com.finalproject.manitoone.controller;
+
+import com.finalproject.manitoone.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/profile")
+public class ProfileViewController {
+
+  private final UserService userService;
+
+  @GetMapping("/{nickname}")
+  public String myPage(@PathVariable String nickname, Model model) {
+    model.addAttribute("user", userService.getUserByNickname(nickname));
+    return "profile";
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/domain/AiPostLog.java
+++ b/src/main/java/com/finalproject/manitoone/domain/AiPostLog.java
@@ -1,0 +1,35 @@
+package com.finalproject.manitoone.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ai_post_log")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiPostLog {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "ai_post_log_id", nullable = false)
+  private Long aiPostLogId;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  @Column(name = "ai_content", nullable = false, columnDefinition = "text")
+  private String aiContent;
+}

--- a/src/main/java/com/finalproject/manitoone/domain/ReplyPost.java
+++ b/src/main/java/com/finalproject/manitoone/domain/ReplyPost.java
@@ -1,0 +1,51 @@
+package com.finalproject.manitoone.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reply_post")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReplyPost {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "reply_post_id", nullable = false)
+  private Long replyPostId;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "content", nullable = false, columnDefinition = "text")
+  private String content;
+
+  @Column(name = "parrent_id")
+  private Long parrentId;
+
+  @Column(name = "is_blind", nullable = false, columnDefinition = "tinyint DEFAULT 0 COMMENT '0. x\\n1. o\\n관리자가 숨길 수 있는 권한'")
+  @Builder.Default
+  private Boolean isBlind = false;
+
+  @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT now()")
+  @Builder.Default
+  private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/com/finalproject/manitoone/dto/post/PostViewResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/post/PostViewResponseDto.java
@@ -1,8 +1,6 @@
 package com.finalproject.manitoone.dto.post;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.finalproject.manitoone.domain.Post;
-import com.finalproject.manitoone.domain.ReplyPost;
 import com.finalproject.manitoone.dto.postimage.PostImageResponseDto;
 import com.finalproject.manitoone.dto.replypost.ReplyPostResponseDto;
 import java.time.LocalDateTime;
@@ -39,15 +37,13 @@ public class PostViewResponseDto {
     this.replies = replies;
   }
 
-  public PostViewResponseDto(Post post) {
-    this.postId = post.getPostId();
-    this.profileImage = post.getUser().getProfileImage();
-    this.nickName = post.getUser().getNickname();
-    this.content = post.getContent();
-    this.createdAt = post.getCreatedAt();
-    this.updatedAt = post.getUpdatedAt();
-    this.postImages = null;
-    this.likeCount = null;
-    this.replies = null;
+  public PostViewResponseDto(Long postId, String profileImage, String nickName,
+      String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    this.postId = postId;
+    this.profileImage = profileImage;
+    this.nickName = nickName;
+    this.content = content;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
 }

--- a/src/main/java/com/finalproject/manitoone/dto/post/PostViewResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/post/PostViewResponseDto.java
@@ -2,7 +2,9 @@ package com.finalproject.manitoone.dto.post;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.finalproject.manitoone.domain.Post;
+import com.finalproject.manitoone.domain.ReplyPost;
 import com.finalproject.manitoone.dto.postimage.PostImageResponseDto;
+import com.finalproject.manitoone.dto.replypost.ReplyPostResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -16,12 +18,14 @@ import lombok.RequiredArgsConstructor;
 public class PostViewResponseDto {
 
   private Long postId;
-  private Long userId;
-  private String content;
+  private String profileImage;
+  private String nickName;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
+  private String content;
   private List<PostImageResponseDto> postImages;
   private Integer likeCount;
+  private List<ReplyPostResponseDto> replies;
 
   public void addPostImages(List<PostImageResponseDto> postImages) {
     this.postImages = postImages;
@@ -31,13 +35,19 @@ public class PostViewResponseDto {
     this.likeCount = likeCount;
   }
 
+  public void addReplies(List<ReplyPostResponseDto> replies) {
+    this.replies = replies;
+  }
+
   public PostViewResponseDto(Post post) {
     this.postId = post.getPostId();
-    this.userId = post.getUser().getUserId();
+    this.profileImage = post.getUser().getProfileImage();
+    this.nickName = post.getUser().getNickname();
     this.content = post.getContent();
     this.createdAt = post.getCreatedAt();
     this.updatedAt = post.getUpdatedAt();
     this.postImages = null;
     this.likeCount = null;
+    this.replies = null;
   }
 }

--- a/src/main/java/com/finalproject/manitoone/dto/replypost/ReplyPostResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/replypost/ReplyPostResponseDto.java
@@ -1,0 +1,17 @@
+package com.finalproject.manitoone.dto.replypost;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReplyPostResponseDto {
+
+  private String nickName;
+  private String profileImage;
+  private String content;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
@@ -1,7 +1,6 @@
 package com.finalproject.manitoone.dto.user;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.finalproject.manitoone.domain.User;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,10 +23,11 @@ public class UserInformationResponseDto {
     this.followings = followings;
   }
 
-  public UserInformationResponseDto(User user) {
-    this.name = user.getName();
-    this.nickname = user.getNickname();
-    this.introduce = user.getIntroduce();
-    this.profileImage = user.getProfileImage();
+  public UserInformationResponseDto(String name, String nickname, String introduce,
+      String profileImage) {
+    this.name = name;
+    this.nickname = nickname;
+    this.introduce = introduce;
+    this.profileImage = profileImage;
   }
 }

--- a/src/main/java/com/finalproject/manitoone/repository/ReplyPostRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/ReplyPostRepository.java
@@ -1,0 +1,13 @@
+package com.finalproject.manitoone.repository;
+
+import com.finalproject.manitoone.domain.ReplyPost;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReplyPostRepository extends JpaRepository<ReplyPost, Long> {
+
+  Optional<List<ReplyPost>> findAllByPost_PostIdAndIsBlindFalse(Long postId);
+}

--- a/src/main/java/com/finalproject/manitoone/service/FollowService.java
+++ b/src/main/java/com/finalproject/manitoone/service/FollowService.java
@@ -16,25 +16,26 @@ public class FollowService {
   private final FollowRepository followRepository;
   private final UserRepository userRepository;
 
-  public Boolean toggleFollow(Long userId, Long targetUserId) {
+  public Boolean toggleFollow(String myNickName, String targetNickName) {
 
-    if (userId.equals(targetUserId)) {
+    if (myNickName.equals(targetNickName)) {
       throw new IllegalArgumentException(IllegalActionMessages.CANNOT_FOLLOW_YOURSELF.getMessage());
     }
 
-    Optional<Follow> follow = followRepository.findByFollower_UserIdAndFollowing_UserId(userId,
-        targetUserId);
+    User my = userRepository.findUserByNickname(myNickName).orElseThrow(
+        () -> new IllegalArgumentException(
+            IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()));
+    User target = userRepository.findUserByNickname(targetNickName).orElseThrow(
+        () -> new IllegalArgumentException(
+            IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()));
+
+    Optional<Follow> follow = followRepository.findByFollower_UserIdAndFollowing_UserId(my.getUserId(),
+        target.getUserId());
 
     if (follow.isPresent()) {
       followRepository.delete(follow.get());
       return Boolean.FALSE;
     } else {
-      User my = userRepository.findById(userId)
-          .orElseThrow(() -> new IllegalArgumentException(
-              IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()));
-      User target = userRepository.findById(targetUserId)
-          .orElseThrow(() -> new IllegalArgumentException(
-              IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()));
       Follow newFollow = new Follow(null, my, target);
       followRepository.save(newFollow);
       return Boolean.TRUE;

--- a/src/main/java/com/finalproject/manitoone/service/PostService.java
+++ b/src/main/java/com/finalproject/manitoone/service/PostService.java
@@ -8,8 +8,10 @@ import com.finalproject.manitoone.domain.dto.AddPostRequestDto;
 import com.finalproject.manitoone.domain.dto.PostResponseDto;
 import com.finalproject.manitoone.dto.post.PostViewResponseDto;
 import com.finalproject.manitoone.dto.postimage.PostImageResponseDto;
+import com.finalproject.manitoone.dto.replypost.ReplyPostResponseDto;
 import com.finalproject.manitoone.repository.PostImageRepository;
 import com.finalproject.manitoone.repository.PostRepository;
+import com.finalproject.manitoone.repository.ReplyPostRepository;
 import com.finalproject.manitoone.repository.UserPostLikeRepository;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -29,6 +31,7 @@ public class PostService {
   private final PostRepository postRepository;
   private final PostImageRepository postImageRepository;
   private final UserPostLikeRepository userPostLikeRepository;
+  private final ReplyPostRepository replyPostRepository;
 
   // 게시글 생성
   public PostResponseDto createPost(AddPostRequestDto request, User user) throws IOException {
@@ -84,7 +87,7 @@ public class PostService {
             IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()));
 
     List<PostViewResponseDto> postResponses = posts.stream()
-        .map(PostViewResponseDto::new)
+        .map(PostViewResponseDto -> new PostViewResponseDto())
         .toList();
 
     return addAdditionalDataToDto(postResponses);
@@ -98,10 +101,12 @@ public class PostService {
         .stream()
         .map(userPostLike -> new PostViewResponseDto(
             userPostLike.getPost().getPostId(),
-            userPostLike.getUser().getUserId(),
-            userPostLike.getPost().getContent(),
+            userPostLike.getUser().getProfileImage(),
+            userPostLike.getUser().getNickname(),
             userPostLike.getPost().getCreatedAt(),
             userPostLike.getPost().getUpdatedAt(),
+            userPostLike.getPost().getContent(),
+            null,
             null,
             null)
         ).toList();
@@ -134,8 +139,16 @@ public class PostService {
       Integer likeCount = userPostLikeRepository.countAllByPost_PostId(postResponseDto.getPostId())
           .orElseThrow(() -> new IllegalArgumentException(
               IllegalActionMessages.CANNOT_FIND_POST_WITH_GIVEN_ID.getMessage()));
+      List<ReplyPostResponseDto> replies = replyPostRepository.findAllByPost_PostIdAndIsBlindFalse(
+              postResponseDto.getPostId()).orElseThrow(() -> new IllegalArgumentException(
+              IllegalActionMessages.CANNOT_FIND_POST_WITH_GIVEN_ID.getMessage()))
+          .stream()
+          .map(reply -> new ReplyPostResponseDto(reply.getUser().getNickname(),
+              reply.getUser().getProfileImage(), reply.getContent(), reply.getCreatedAt()))
+          .toList();
       postResponseDto.addLikeCount(likeCount);
       postResponseDto.addPostImages(postImages);
+      postResponseDto.addReplies(replies);
     });
 
     return postResponses;

--- a/src/main/java/com/finalproject/manitoone/service/PostService.java
+++ b/src/main/java/com/finalproject/manitoone/service/PostService.java
@@ -87,7 +87,10 @@ public class PostService {
             IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()));
 
     List<PostViewResponseDto> postResponses = posts.stream()
-        .map(PostViewResponseDto -> new PostViewResponseDto())
+        .map(post -> new PostViewResponseDto(post.getPostId(), post.getUser().getProfileImage(),
+            post.getUser().getNickname(), post.getContent(), post.getCreatedAt(),
+            post.getUpdatedAt()
+        ))
         .toList();
 
     return addAdditionalDataToDto(postResponses);
@@ -103,12 +106,9 @@ public class PostService {
             userPostLike.getPost().getPostId(),
             userPostLike.getUser().getProfileImage(),
             userPostLike.getUser().getNickname(),
-            userPostLike.getPost().getCreatedAt(),
-            userPostLike.getPost().getUpdatedAt(),
             userPostLike.getPost().getContent(),
-            null,
-            null,
-            null)
+            userPostLike.getPost().getCreatedAt(),
+            userPostLike.getPost().getUpdatedAt())
         ).toList();
 
     return addAdditionalDataToDto(postResponses);
@@ -120,7 +120,14 @@ public class PostService {
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()))
         .stream()
-        .map(PostViewResponseDto::new)
+        .map(post -> new PostViewResponseDto(
+            post.getPostId(),
+            post.getUser().getProfileImage(),
+            post.getUser().getNickname(),
+            post.getContent(),
+            post.getCreatedAt(),
+            post.getUpdatedAt()
+        ))
         .toList();
 
     return addAdditionalDataToDto(postResponses);

--- a/src/main/java/com/finalproject/manitoone/service/UserService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserService.java
@@ -21,23 +21,25 @@ public class UserService {
     User user = userRepository.findUserByNickname(nickname)
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.CANNOT_FIND_USER_BY_GIVEN_NICKNAME.getMessage()));
-    UserInformationResponseDto userInformation = new UserInformationResponseDto(
-        userRepository.findUserByNickname(nickname)
-            .orElseThrow(() -> new IllegalArgumentException(
-                IllegalActionMessages.CANNOT_FIND_USER_BY_GIVEN_NICKNAME.getMessage())));
+    UserInformationResponseDto userInformation = new UserInformationResponseDto(user.getName(),
+        user.getNickname(), user.getIntroduce(), user.getProfileImage());
 
     List<Follow> followersList = followRepository.findAllByFollower_UserId(user.getUserId())
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.CANNOT_GET_FOLLOWERS.getMessage()));
     List<UserInformationResponseDto> followers = followersList.stream()
-        .map(follow -> new UserInformationResponseDto(follow.getFollowing()))
+        .map(follow -> new UserInformationResponseDto(follow.getFollowing().getName(),
+            follow.getFollowing().getNickname(), follow.getFollowing().getIntroduce(),
+            follow.getFollowing().getProfileImage()))
         .toList();
 
     List<Follow> followingsList = followRepository.findAllByFollowing_UserId(user.getUserId())
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.CANNOT_GET_FOLLOWING.getMessage()));
     List<UserInformationResponseDto> followings = followingsList.stream()
-        .map(follow -> new UserInformationResponseDto(follow.getFollower()))
+        .map(follow -> new UserInformationResponseDto(follow.getFollower().getName(),
+            follow.getFollower().getNickname(), follow.getFollower().getIntroduce(),
+            follow.getFollower().getProfileImage()))
         .toList();
 
     userInformation.setFollow(followers, followings);

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -1,0 +1,252 @@
+<!--헤더, 우측 메뉴는 고정으로 페이지 자체가 넘어가는 것이 아니면 그 외의 화면 요소만 fragment로 로드합니다.-->
+<!--fragments/common -> 자잘히 쪼개진 공통 요소들-->
+<!--fragments/content -> 유사 페이지. 헤더, 우측 메뉴를 제외한 중앙 섹션 컨텐츠-->
+<!--fragments/modals -> 모달창 요소-->
+<!--pages/auth -> 로그인, 회원가입 페이지-->
+<!--페이지 자체가 따로 필요한 경우 pages에 추가해주시고-->
+<!--피그마 기반으로 기본 틀만 구성한 거라 없는 부분도 많고 기능은 다 빠져 있으니 자유롭게 추가/수정하십쇼-->
+<!--미구현 : 답글 모달, 관리자 페이지, 탭메뉴 이동, 더보기 메뉴, 게시물 상세로 이동하는 기능 등-->
+
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" th:href="@{/style/reset.css}"/>
+  <link rel="stylesheet" th:href="@{/style/common.css}"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
+      rel="stylesheet"
+  />
+  <link
+      rel="icon"
+      type="image/x-icon"
+      th:href="@{/images/favicon/favicon.ico}"
+  />
+  <title>ManiToOne</title>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      let pageNum = 0;
+      const userNickName = '[[${user.nickname}]]';
+      const postsContainer = document.getElementById("postsContainer");
+      let isLoading = false;
+      let hasMorePosts = true;
+      let currentCategory = 1; // 1: 내 피드, 2: 좋아요 누른 피드, 3: 숨긴 피드
+
+      window.addEventListener('scroll', function () {
+        if (window.innerHeight + window.scrollY >= document.body.scrollHeight - 100) {
+          if (!isLoading && hasMorePosts) {
+            isLoading = true;
+            pageNum++;
+            loadPosts(pageNum);
+          }
+        }
+      });
+
+      // 카테고리 버튼 클릭 이벤트 처리
+      document.querySelector('.my-post-menu-switch').addEventListener('click', function() {
+        currentCategory = 1;
+        pageNum = 0; // 페이지 번호 초기화
+        hasMorePosts = true; // 게시물 로드 여부 초기화
+        postsContainer.innerHTML = ''; // 기존 게시물 비우기
+        loadPosts(pageNum); // 내 피드 게시물 로드
+      });
+
+      document.querySelector('.like-it-menu-switch').addEventListener('click', function() {
+        currentCategory = 2;
+        pageNum = 0; // 페이지 번호 초기화
+        hasMorePosts = true; // 게시물 로드 여부 초기화
+        postsContainer.innerHTML = ''; // 기존 게시물 비우기
+        loadPosts(pageNum); // 좋아요 누른 피드 게시물 로드
+      });
+
+      document.querySelector('.hidden-post-menu-switch').addEventListener('click', function() {
+        currentCategory = 3;
+        pageNum = 0; // 페이지 번호 초기화
+        hasMorePosts = true; // 게시물 로드 여부 초기화
+        postsContainer.innerHTML = ''; // 기존 게시물 비우기
+        loadPosts(pageNum); // 숨긴 피드 게시물 로드
+      });
+
+      function loadPosts(pageNum) {
+        let apiUrl = '';
+
+        // 카테고리별로 다른 API URL 설정
+        if (currentCategory === 1) {
+          apiUrl = `/api/post/by/[[${nickname}]]?page=${pageNum}`;
+        } else if (currentCategory === 2) {
+          apiUrl = `/api/post/[[${nickname}]]/liked?page=${pageNum}`;
+        } else if (currentCategory === 3) {
+          apiUrl = `/api/post/hidden?page=${pageNum}`;
+        }
+
+        fetch(apiUrl)
+        .then(response => response.json())
+        .then(posts => {
+          if (posts && posts.length > 0) {
+            posts.forEach(post => {
+              const postElement = createPostElement(post);
+              postsContainer.appendChild(postElement);
+            });
+          } else {
+            hasMorePosts = false; // 더 이상 게시물이 없으면 hasMorePosts를 false로 설정
+          }
+          isLoading = false;
+
+          // 게시물이 로드된 후에 addFriendButtons 이벤트 리스너 추가
+          addFriendButtonsEventListener();
+        })
+        .catch(error => {
+          console.error('Error loading posts:', error);
+          isLoading = false;
+        });
+      }
+
+      function createPostElement(post) {
+        const postElement = document.createElement("div");
+        postElement.classList.add("post-container");
+
+        const timeText = post.updatedAt ? `(수정됨) ${timeForToday(post.updatedAt)}` : timeForToday(post.createdAt);
+
+        postElement.innerHTML = `
+      <img class="user-photo" src="${post.profileImage || '/images/icons/UI-user2.png'}" alt="user icon" />
+      <div class="post-content">
+        <div class="user-info">
+          <span class="user-name">${post.nickName}</span>
+          <span class="passed-time" data-created-at="${post.createdAt}" data-updated-at="${post.updatedAt}">${timeText}</span>
+        </div>
+        <p class="content-text">${post.content}</p>
+        <div class="reaction-icons">
+          <img class="tiny-icons" src="/images/icons/icon-clover2.png" alt="I like this" />
+          <span class="like-count">${post.likeCount}</span>
+          <img class="tiny-icons" src="/images/icons/icon-comment2.png" alt="add reply" />
+          <span class="reply-count">${post.replies.length}</span>
+        </div>
+      </div>
+      <div class="option-icons">
+        <img class="tiny-icons" src="/images/icons/UI-more2.png" alt="more options" />
+        ${userNickName !== post.nickName ? '<img class="tiny-icons" src="/images/icons/icon-add-friend.png" alt="add friend" data-target-id="' + post.nickName + '"/>' : ''}
+      </div>
+    `;
+        return postElement;
+      }
+
+      function timeForToday(value) {
+        const today = new Date();
+        const timeValue = new Date(value);
+
+        const betweenTime = Math.floor((today.getTime() - timeValue.getTime()) / 1000 / 60);
+        if (betweenTime < 1) {
+          return '방금전';
+        }
+        if (betweenTime < 60) {
+          return `${betweenTime}분전`;
+        }
+        const betweenTimeHour = Math.floor(betweenTime / 60);
+        if (betweenTimeHour < 24) {
+          return `${betweenTimeHour}시간전`;
+        }
+        const betweenTimeDay = Math.floor(betweenTime / 60 / 24);
+        if (betweenTimeDay < 30) {
+          return `${betweenTimeDay}일전`;
+        }
+        if (betweenTimeDay < 365) {
+          return `${Math.floor(betweenTimeDay / 30)}개월전`;
+        }
+        return `${Math.floor(betweenTimeDay / 365)}년전`;
+      }
+
+      function addFriendButtonsEventListener() {
+        const addFriendButtons = document.querySelectorAll('img[alt="add friend"]');
+
+        addFriendButtons.forEach(button => {
+          button.addEventListener("click", function () {
+            // TODO: 하드코딩된 내 아이디 제거
+            const myId = '테스트1';
+            const targetId = this.dataset.targetId;
+
+            // API 호출
+            fetch(`/api/follow/${myId}/${targetId}`)
+            .then(response => {
+              if (response.status === 201) {
+                location.reload();
+                this.alt = "remove friend"; // 팔로우 버튼을 언팔로우 버튼으로 변경
+              } else if (response.status === 200) {
+                location.reload();
+                this.alt = "add friend"; // 언팔로우 버튼을 팔로우 버튼으로 변경
+              } else if (response.status === 500) {
+                alert("wtf?");
+              }
+
+            })
+            .catch(error => {
+              console.error("API 호출 중 오류 발생:", error);
+            });
+          });
+        });
+      }
+
+      // 초기 로딩
+      loadPosts(pageNum);
+    });
+  </script>
+</head>
+<body>
+<header th:replace="fragments/common/header :: header"></header>
+<main class="main-container">
+  <section class="middle-section" id="middleSection">
+    <section class="mypage-section" th:fragment="mypage">
+      <div class="profile-container">
+        <div class="profile-title">프로필</div>
+        <div class="profile-content">
+          <div class="profile-user-info">
+            <div class="user-name-box">
+              <p class="user-name" th:text="${user.getName()}">이름</p>
+              <p class="user-nickname" th:text="${user.getNickname()}">닉네임</p>
+            </div>
+            <p class="user-introduce" th:text="${user.getIntroduce()}">소개</p>
+            <p class="follower-count">팔로워 [[${user.getFollowings().size()}]]명</p>
+          </div>
+          <div class="profile-user-photo">
+            <img
+                class="user-photo"
+                th:src="@{/images/icons/UI-user2.png}"
+                alt="user icon"
+            />
+          </div>
+        </div>
+        <button class="profile-update-button" id="openProfileUpdateBtn">
+          프로필 수정
+        </button>
+      </div>
+      <div class="mypage-menu-switch">
+        <button class="my-post-menu-switch">내 피드</button>
+        <button class="like-it-menu-switch">좋아요 누른 피드</button>
+        <button class="hidden-post-menu-switch">숨긴 피드</button>
+      </div>
+      <div class="new-post-form">
+        <img
+            class="user-photo"
+            th:src="@{/images/icons/UI-user2.png}"
+            alt="user icon"
+        />
+        <p id="openPostFormModalBtn">함께 나누고픈 감정이 있나요?</p>
+      </div>
+      <div th:replace="fragments/modals/profile-update-modal :: profile-update-modal"></div>
+      <div th:replace="fragments/modals/new-post-modal :: new-post-modal"></div>
+      <!--작성 시간, 답글 보이지 않는 가장 기본 게시글 덩어리-->
+      <div id="postsContainer" class="posts-container">
+
+      </div>
+    </section>
+  </section>
+  <article
+      th:replace="fragments/common/right-section :: right-section"
+  ></article>
+</main>
+<script th:src="@{/script/common.js}"></script>
+<script th:src="@{/script/newPost.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## :mag_right: 작업 내용
- 마이페이지 및 타 유저 페이지를 통합하였습니다.
- 무한 스크롤 구현 및 내가 작성한 게시글은 팔로우 버튼이 나오지 않게 수정하였습니다.
- 팔로우 기능을 유저간의 닉네임으로 가능하도록 변경하였습니다.
- Dto에서도 엔티티의 존재를 알 수 없게 수정하였습니다.
- 수정된 게시글은 (수정됨) 을 붙여 수정 유무를 알 수 있게 하였습니다.
- 게시물의 작성 시간을 n분전 등 시간 차이로 표기하게 변경하였습니다.
- 게시물의 답글 갯수를 받아와서 보여주도록 하였습니다.


## ⚫️이미지 첨부

![test](https://github.com/user-attachments/assets/06e7b81f-1003-4870-a972-afe8a33c6f8e)


## :heavy_plus_sign: 이슈 링크
- #51 
