### PR TITLE
feat : 회원 탈퇴 기능 추가 및 회원가입 & 로그인 부분 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/finalproject/manitoone/config/SecurityConfig.java
+++ b/src/main/java/com/finalproject/manitoone/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.finalproject.manitoone.config;
 
+import com.finalproject.manitoone.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,8 +11,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final CustomOAuth2UserService customOAuth2UserService;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -19,9 +23,20 @@ public class SecurityConfig {
             // .antMatchers("/admin/"**).hasRole("ADMIN") // 어드민 페이지 생성 및 롤 생성 시 활성화
             .anyRequest().permitAll()
         )
-//        .formLogin(custom -> custom
-//            .loginPage("/login")
-//            )
+        .formLogin(custom -> custom
+            .loginPage("/api/local-login")
+            .loginProcessingUrl("/login")
+            .defaultSuccessUrl("/")
+            .permitAll()
+        )
+        .oauth2Login(oauth2 -> oauth2
+            .loginPage("/login")
+            .userInfoEndpoint(userInfoEndpointConfig ->
+                userInfoEndpointConfig.userService(customOAuth2UserService))
+            .defaultSuccessUrl("/", true)
+            .failureUrl("/login?error=true")
+            .permitAll()
+        )
         .logout(custom -> custom
             .logoutSuccessUrl("/")
             .invalidateHttpSession(true)

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -59,4 +60,9 @@ public class UserAuthController {
     }
   }
 
+  @DeleteMapping("/cancel-account")
+  public ResponseEntity<String> deleteUser(@RequestBody UserLoginRequestDto userLoginRequestDto) {
+    userAuthService.deleteUser(userLoginRequestDto.getEmail(), userLoginRequestDto.getPassword());
+    return ResponseEntity.ok("회원 탈퇴 처리되었습니다.");
+  }
 }

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -4,6 +4,7 @@ import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.domain.dto.UserLoginRequestDto;
 import com.finalproject.manitoone.domain.dto.UserLoginResponseDto;
 import com.finalproject.manitoone.domain.dto.UserSignUpDTO;
+import com.finalproject.manitoone.service.CustomOAuth2UserService;
 import com.finalproject.manitoone.service.UserAuthService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAuthController {
 
   private final UserAuthService userAuthService;
+  private final CustomOAuth2UserService customOAuth2UserService;
 
   @PostMapping("/signup")
   public ResponseEntity<String> signUp(
@@ -57,6 +59,16 @@ public class UserAuthController {
     } catch (IllegalArgumentException e) {
       return ResponseEntity.badRequest()
           .body(new IllegalArgumentException(IllegalActionMessages.USER_NOT_FOUND.getMessage()));
+    }
+  }
+
+  @PostMapping("/oauth-login")
+  public ResponseEntity<Object> oauthLogin() {
+    try {
+      UserLoginResponseDto userInfo = customOAuth2UserService.getUserInfoFromSession();
+      return ResponseEntity.ok(userInfo);
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.status(401).body(e.getMessage());
     }
   }
 

--- a/src/main/java/com/finalproject/manitoone/domain/User.java
+++ b/src/main/java/com/finalproject/manitoone/domain/User.java
@@ -78,8 +78,9 @@ public class User implements OAuth2User {
   @Column(name = "login_id", nullable = true, columnDefinition = "oauth id")
   private String loginId;
 
-  @Column(name = "provider", nullable = false, columnDefinition = "google, kakao, ..., ")
-  private String provider;
+  @Column(name = "provider", nullable = false, columnDefinition = "google, local, ..., ")
+  @Builder.Default
+  private String provider = "Local";
 
   @Transient
   private Map<String, Object> attributes;

--- a/src/main/java/com/finalproject/manitoone/domain/User.java
+++ b/src/main/java/com/finalproject/manitoone/domain/User.java
@@ -6,12 +6,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 @Entity
 @Table(name = "user")
@@ -19,7 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User {
+public class User implements OAuth2User {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -68,6 +75,15 @@ public class User {
   @Builder.Default
   private LocalDateTime createdAt = LocalDateTime.now();
 
+  @Column(name = "login_id", nullable = true, columnDefinition = "oauth id")
+  private String loginId;
+
+  @Column(name = "provider", nullable = false, columnDefinition = "google, kakao, ..., ")
+  private String provider;
+
+  @Transient
+  private Map<String, Object> attributes;
+
   public void setPassword(String password) {
     this.password = password;
   }
@@ -76,4 +92,21 @@ public class User {
     this.status = status;
   }
 
+  public void setLoginId(String loginId) {
+    this.loginId = loginId;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+  }
 }

--- a/src/main/java/com/finalproject/manitoone/domain/User.java
+++ b/src/main/java/com/finalproject/manitoone/domain/User.java
@@ -71,4 +71,9 @@ public class User {
   public void setPassword(String password) {
     this.password = password;
   }
+
+  public void setStatus(Integer status) {
+    this.status = status;
+  }
+
 }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/CustomOAuth2User.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/CustomOAuth2User.java
@@ -1,0 +1,48 @@
+package com.finalproject.manitoone.domain.dto;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+  private final OAuth2Response oAuth2Response; // 커스텀 OAuth2 데이터 매핑 클래스
+  private final Map<String, Object> attributes; // OAuth2 공급자로부터 받은 원본 데이터
+  private final Collection<? extends GrantedAuthority> authorities; // 권한 정보
+
+  // 사용자 속성 반환 (OAuth2User 필수 메서드)
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  // 사용자 이름 반환 (OAuth2User 필수 메서드)
+  @Override
+  public String getName() {
+    return oAuth2Response.getName();
+  }
+
+  // 사용자 권한 반환 (Spring Security 필수 메서드)
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return authorities;
+  }
+
+  // 추가 메서드: 이메일 정보 가져오기
+  public String getEmail() {
+    return oAuth2Response.getEmail();
+  }
+
+  // 추가 메서드: OAuth2 공급자 정보 가져오기
+  public String getProvider() {
+    return oAuth2Response.getProvider();
+  }
+
+  // 추가 메서드: 공급자별 사용자 고유 ID 가져오기
+  public String getProviderId() {
+    return oAuth2Response.getProviderId();
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/domain/dto/OAuth2Response.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/OAuth2Response.java
@@ -1,0 +1,12 @@
+package com.finalproject.manitoone.domain.dto;
+
+public interface OAuth2Response {
+
+  String getProvider();
+
+  String getProviderId();
+
+  String getEmail();
+
+  String getName();
+}

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserSignUpDTO.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserSignUpDTO.java
@@ -41,6 +41,8 @@ public class UserSignUpDTO {
   @NotNull(message = "생년월일은 필수 입력값입니다.")
   private LocalDate birth;
 
+  private String provider;
+
   public User toEntity(String encryptedPassword) {
     return User.builder()
         .email(this.email)
@@ -48,6 +50,7 @@ public class UserSignUpDTO {
         .name(this.name)
         .nickname(this.nickname)
         .birth(this.birth)
+        .provider(this.provider)
         .build();
   }
 }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserSignUpDTO.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserSignUpDTO.java
@@ -41,8 +41,6 @@ public class UserSignUpDTO {
   @NotNull(message = "생년월일은 필수 입력값입니다.")
   private LocalDate birth;
 
-  private String provider;
-
   public User toEntity(String encryptedPassword) {
     return User.builder()
         .email(this.email)
@@ -50,7 +48,6 @@ public class UserSignUpDTO {
         .name(this.name)
         .nickname(this.nickname)
         .birth(this.birth)
-        .provider(this.provider)
         .build();
   }
 }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/admin/GoogleResponse.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/admin/GoogleResponse.java
@@ -1,0 +1,33 @@
+package com.finalproject.manitoone.domain.dto.admin;
+
+import com.finalproject.manitoone.domain.dto.OAuth2Response;
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response {
+
+  private final Map<String, Object> attributes; // Google OAuth2 응답 데이터
+
+  public GoogleResponse(Map<String, Object> attributes) {
+    this.attributes = attributes;
+  }
+
+  @Override
+  public String getProvider() {
+    return "google"; // Google 고정 값
+  }
+
+  @Override
+  public String getProviderId() {
+    return (String) attributes.get("sub"); // Google의 고유 사용자 ID
+  }
+
+  @Override
+  public String getEmail() {
+    return (String) attributes.get("email"); // 이메일
+  }
+
+  @Override
+  public String getName() {
+    return (String) attributes.get("name"); // 사용자 이름
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/finalproject/manitoone/service/CustomOAuth2UserService.java
@@ -1,0 +1,101 @@
+package com.finalproject.manitoone.service;
+
+import com.finalproject.manitoone.domain.User;
+import com.finalproject.manitoone.domain.dto.CustomOAuth2User;
+import com.finalproject.manitoone.domain.dto.UserLoginResponseDto;
+import com.finalproject.manitoone.domain.dto.admin.GoogleResponse;
+import com.finalproject.manitoone.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+  private final HttpSession session;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+    // 기본 OAuth2 사용자 정보 로드
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+    log.info("Google OAuth2User attributes: {}", oAuth2User.getAttributes());
+
+    // 사용자 정보 매핑
+    Map<String, Object> attributes = oAuth2User.getAttributes();
+    String provider = "google"; // 고정 값
+    String providerId = (String) attributes.get("sub"); // Google의 고유 사용자 ID
+    String email = (String) attributes.get("email");
+    String name = (String) attributes.get("name");
+
+    // 사용자 조회: 이메일과 이름을 조합하여 조회
+    // todo 하드코딩, 잘못 들어가는 값들 고치기 => 생일, 비밀번호
+    User user = userRepository.findByEmail(email)
+        .orElseGet(() -> User.builder()
+            .email(email)
+            .password("DefaultPassword!1")
+            .name(name)
+            .nickname(name)
+            .birth(LocalDate.now())
+            .provider(provider)
+            .loginId(providerId)
+            .build()
+        );
+
+    // 사용자 정보 업데이트
+    user.setLoginId(providerId);
+    user.setProvider(provider);
+    userRepository.save(user);
+
+    log.info("User saved or updated: {}", user);
+
+    // 인증된 사용자 정보를 반환
+    return new CustomOAuth2User(
+        new GoogleResponse(attributes), // GoogleResponse로 매핑
+        attributes,
+        oAuth2User.getAuthorities()
+    );
+  }
+
+  // 세션에 정보 저장
+  private void saveUserInfoToSession(User user) {
+    session.setAttribute("email", user.getEmail());
+    session.setAttribute("name", user.getName());
+    session.setAttribute("nickname", user.getNickname());
+    session.setAttribute("profileImage", user.getProfileImage());
+    session.setAttribute("introduce", user.getIntroduce());
+  }
+  
+  // 세션에서 사용자 정보를 가져옴
+  public UserLoginResponseDto getUserInfoFromSession() {
+    String email = (String) session.getAttribute("email");
+    String name = (String) session.getAttribute("name");
+    String nickname = (String) session.getAttribute("nickname");
+    String profileImage = (String) session.getAttribute("profileImage");
+    String introduce = (String) session.getAttribute("introduce");
+
+    // 세션에 값이 없을 경우 처리
+    if (email == null) {
+      throw new IllegalArgumentException("OAuth2 인증이 완료되지 않았습니다.");
+    }
+
+    return UserLoginResponseDto.builder()
+        .email(email)
+        .name(name)
+        .nickname(nickname)
+        .profileImage(profileImage)
+        .introduce(introduce)
+        .build();
+  }
+}
+

--- a/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
+++ b/src/main/java/com/finalproject/manitoone/service/UserAuthService.java
@@ -44,7 +44,7 @@ public class UserAuthService {
   }
 
   @Transactional
-  public UserLoginResponseDto localLogin(String email, String password) {
+  public User validateUserCredentials(String email, String password) {
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.INVALID_EMAIL_OR_PASSWORD.getMessage()));
@@ -54,6 +54,24 @@ public class UserAuthService {
           IllegalActionMessages.INVALID_EMAIL_OR_PASSWORD.getMessage());
     }
 
+    if (user.getStatus() != 1) {
+      throw new IllegalArgumentException("로그인할 수 없는 상태입니다.");
+    }
+
+    return user;
+  }
+
+
+  @Transactional
+  public UserLoginResponseDto localLogin(String email, String password) {
+    User user = validateUserCredentials(email, password);
     return new UserLoginResponseDto(user);
   }
+
+  @Transactional
+  public void deleteUser(String email, String password) {
+    User user = validateUserCredentials(email, password);
+    user.setStatus(3);
+  }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,9 @@ spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.starttls.enable=true
 
 spring.thymeleaf.cache=false
+
+# OAuth - Google
+spring.security.oauth2.client.registration.google.client-id=
+spring.security.oauth2.client.registration.google.client-secret=
+spring.security.oauth2.client.registration.google.scope=email,profile
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google

--- a/src/main/resources/static/style/sign-up.css
+++ b/src/main/resources/static/style/sign-up.css
@@ -4,3 +4,8 @@
   margin-top: 5px;
   display: block;
 }
+
+input[readonly] {
+  color: #a9a9a9;
+  cursor: not-allowed;
+}

--- a/src/main/resources/templates/pages/auth/email-auth.html
+++ b/src/main/resources/templates/pages/auth/email-auth.html
@@ -140,13 +140,20 @@
         verificationCode: parseInt(authCode, 10),
       }),
     })
-    .then(response => response.text())
+    .then(response => {
+      if (response.ok) {
+        return response.text();
+      } else {
+        return response.text().then(errorText => {
+          throw new Error(errorText);
+        });
+      }
+    })
     .then(data => {
       if (data) {
         alert('이메일 인증이 완료되었습니다!');
+        localStorage.setItem('verifiedEmail', emailInput);
         window.location.href = '/register-info';
-      } else {
-        alert('인증 실패: ' + data);
       }
     })
     .catch(error => {
@@ -158,7 +165,7 @@
   // 모달 닫기
   document.querySelector('.close-button').addEventListener('click', function () {
     document.getElementById('emailAuthModal').style.display = 'none';
-    document.getElementById("modalOverlay").style.display= 'none';
+    document.getElementById("modalOverlay").style.display = 'none';
   });
 </script>
 </body>

--- a/src/main/resources/templates/pages/auth/find-password-after.html
+++ b/src/main/resources/templates/pages/auth/find-password-after.html
@@ -19,18 +19,28 @@
   <div class="logo-box">
     <img th:src="@{/images/logo/long-logo.png}" alt="ManiToOne logo"/>
   </div>
-  <p class="find-password-discription">
-    xxx@mail.com 이메일로 임시 비밀번호를 전송했습니다.
-  </p>
+  <p class="find-password-discription"></p>
   <button class="move-to-sign-in-button">
     로그인 페이지로 이동하기
   </button>
-
-  <script>
-    document.querySelector(".move-to-sign-in-button").addEventListener("click", function () {
-      window.location.href = "/login";
-    });
-  </script>
 </section>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const email = sessionStorage.getItem("resultEmail");
+    if (email) {
+      document.querySelector(
+          ".find-password-discription").textContent = `${email}로 임시 비밀번호가 전송되었습니다.`;
+    } else {
+      document.querySelector(
+          ".find-password-discription").textContent = "이메일 정보가 없습니다. 다시 시도해 주세요.";
+    }
+    sessionStorage.removeItem("resetEmail");
+  });
+
+  document.querySelector(".move-to-sign-in-button").addEventListener("click", function () {
+    window.location.href = "/login";
+  });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/pages/auth/find-password.html
+++ b/src/main/resources/templates/pages/auth/find-password.html
@@ -78,6 +78,7 @@
     })
     .then(response => {
       if (response.ok) {
+        sessionStorage.setItem("resultEmail", requestData.email);
         return response.text();
       } else {
         return response.text().then(errorText => {

--- a/src/main/resources/templates/pages/auth/sign-in.html
+++ b/src/main/resources/templates/pages/auth/sign-in.html
@@ -53,17 +53,16 @@
     <hr class="sign-in-devider-line"/>
   </div>
   <div class="external-login-container">
-    <button class="kakao-login">
-      <img
-          th:src="@{/images/logo/external-login-logo/google-login.png}"
-          alt=""
-      />
-    </button>
+<!--    <button class="kakao-login">-->
+<!--      <img-->
+<!--          th:src="@{/images/logo/external-login-logo/google-login.png}"-->
+<!--          alt=""-->
+<!--      />-->
+<!--    </button>-->
     <button class="google-login">
-      <img
-          th:src="@{/images/logo/external-login-logo/kakao-login.png}"
-          alt=""
-      />
+      <a th:href="@{/oauth2/authorization/google}" class="google-login">
+        <img th:src="@{/images/logo/external-login-logo/google-login.png}" alt="Google 로그인"/>
+      </a>
     </button>
   </div>
   <div class="sign-up-link-container">

--- a/src/main/resources/templates/pages/auth/sign-up.html
+++ b/src/main/resources/templates/pages/auth/sign-up.html
@@ -92,6 +92,16 @@
 </section>
 
 <script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const savedEmail = localStorage.getItem('verifiedEmail');
+    if (savedEmail) {
+      const emailInput = document.getElementById('user-email');
+      emailInput.value = savedEmail;
+      emailInput.setAttribute('readonly', true); // 수정 불가능하게 설정
+      localStorage.removeItem('verifiedEmail');
+    }
+  });
+
   document.getElementById("sign-up-form").addEventListener("submit", function (event) {
     event.preventDefault();
 

--- a/src/main/resources/templates/pages/auth/sign-up.html
+++ b/src/main/resources/templates/pages/auth/sign-up.html
@@ -163,8 +163,8 @@
       isValid = false;
     }
 
-    if (!birth) {
-      birthError.textContent = "생년월일은 필수 입력값입니다.";
+    if (new Date(birth) > new Date()) {
+      birthError.textContent = "미래 날짜는 입력할 수 없습니다.";
       if (!firstErrorField) {
         firstErrorField = document.getElementById("user-birthday");
       }


### PR DESCRIPTION
## :mag_right: 작업 내용

- 회원 탈퇴 기능이 추가되었습니다.
- 기존에 있던 로그인 부분과 회원 탈퇴 기능이 유사하여, 따로 메서드로 가공했습니다.
- 회원 탈퇴 시 로그인과 비슷하게 email, password를 한번 더 입력해야 하도록 했습니다.

- 이메일 인증 시 잘못된 인증번호를 입력해도 인증이 가능했던 오류를 수정했습니다.
- 이메일 인증 후 회원가입 시, 인증받은 이메일을 고정하여 회원가입이 가능하도록 수정했습니다. 

- OAuth2 기능(Google 로그인)이 추가되었습니다.

## ⚫️이미지 첨부



## :heavy_plus_sign: 이슈 링크

- [#72]
