### PR TITLE
프로필 상세 구현 작업

### DIFF
--- a/src/main/java/com/finalproject/manitoone/controller/FollowController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/FollowController.java
@@ -1,6 +1,7 @@
 package com.finalproject.manitoone.controller;
 
 import com.finalproject.manitoone.service.FollowService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,11 +17,11 @@ public class FollowController {
 
   private final FollowService followService;
 
-  @GetMapping("/{myNickName}/{targetNickName}")
-  public ResponseEntity<Void> followUnfollow(@PathVariable String myNickName,
-      @PathVariable String targetNickName) {
-    // TODO: 내 유저의 ID를 추후 세션에서 받아오도록 변경 필요
-    if (Boolean.TRUE.equals(followService.toggleFollow(myNickName, targetNickName))) {
+  @GetMapping("/{targetNickName}")
+  public ResponseEntity<Void> followUnfollow(
+      @PathVariable String targetNickName, HttpSession session) {
+    if (Boolean.TRUE.equals(
+        followService.toggleFollow((String) session.getAttribute("nickname"), targetNickName))) {
       return ResponseEntity.status(HttpStatus.CREATED).build();
     } else {
       return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/com/finalproject/manitoone/controller/ProfileViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/ProfileViewController.java
@@ -1,6 +1,7 @@
 package com.finalproject.manitoone.controller;
 
 import com.finalproject.manitoone.service.UserService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,7 +17,8 @@ public class ProfileViewController {
   private final UserService userService;
 
   @GetMapping("/{nickname}")
-  public String myPage(@PathVariable String nickname, Model model) {
+  public String myPage(@PathVariable String nickname, Model model, HttpSession session) {
+    model.addAttribute("nickname", session.getAttribute("nickname"));
     model.addAttribute("user", userService.getUserByNickname(nickname));
     return "profile";
   }

--- a/src/main/java/com/finalproject/manitoone/controller/api/PostController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/PostController.java
@@ -132,7 +132,7 @@ public class PostController {
 
   @GetMapping("/hidden")
   public ResponseEntity<List<PostViewResponseDto>> getPostById(
-      @PageableDefault(sort = "postId", direction = Sort.Direction.DESC) Pageable pageable) {
-    return ResponseEntity.ok(postService.getMyHiddenPosts("테스트1", pageable));
+      @PageableDefault(sort = "postId", direction = Sort.Direction.DESC) Pageable pageable, HttpSession session) {
+    return ResponseEntity.ok(postService.getMyHiddenPosts((String)session.getAttribute("nickname"), pageable));
   }
 }

--- a/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/user/UserInformationResponseDto.java
@@ -14,13 +14,13 @@ public class UserInformationResponseDto {
   private String nickname;
   private String introduce;
   private String profileImage;
-  private List<UserInformationResponseDto> followers;
   private List<UserInformationResponseDto> followings;
+  private List<UserInformationResponseDto> followers;
 
-  public void setFollow(List<UserInformationResponseDto> followers,
-      List<UserInformationResponseDto> followings) {
-    this.followers = followers;
+  public void setFollow(List<UserInformationResponseDto> followings,
+      List<UserInformationResponseDto> followers) {
     this.followings = followings;
+    this.followers = followers;
   }
 
   public UserInformationResponseDto(String name, String nickname, String introduce,

--- a/src/main/java/com/finalproject/manitoone/service/PostService.java
+++ b/src/main/java/com/finalproject/manitoone/service/PostService.java
@@ -247,8 +247,6 @@ public class PostService {
   }
 
   public List<PostViewResponseDto> getPostsByNickName(String nickName, Pageable pageable) {
-    // TODO: 내 게시글인지는 어떻게 판별할까요?
-    // → 세션 기반 로그인 완성 시 세션에서 받아올 예정
     List<Post> posts = postRepository.findAllByIsBlindFalseAndIsHiddenFalseAndUser_Nickname(
             nickName,
             pageable)

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -12,6 +12,9 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.min.js"></script>
+
   <link rel="stylesheet" th:href="@{/style/reset.css}"/>
   <link rel="stylesheet" th:href="@{/style/common.css}"/>
   <link rel="stylesheet" th:href="@{/style/profile.css}">
@@ -27,7 +30,8 @@
       th:href="@{/images/favicon/favicon.ico}"
   />
   <script th:inline="javascript">
-    var userNickName = /*[[${user.nickname}]]*/ '테스트1';
+    const userNickName = [[${user.getNickname()}]]
+    const myNickName = [[${nickname}]]
   </script>
   <script th:src="@{/script/profile.js}"></script>
   <title>ManiToOne</title>
@@ -46,7 +50,10 @@
               <p class="user-nickname" th:text="${user.getNickname()}">닉네임</p>
             </div>
             <p class="user-introduce" th:text="${user.getIntroduce()}">소개</p>
-            <p class="follower-count">팔로워 [[${user.getFollowings().size()}]]명</p>
+            <div class="d-flex gap-3">
+              <a class="follower-count" href="#" id="followerLink">팔로워 [[${user.getFollowers().size()}]]명</a>
+              <a class="follower-count" href="#" id="followingLink">팔로잉 [[${user.getFollowings().size()}]]명</a>
+            </div>
           </div>
           <div class="profile-user-photo">
             <img
@@ -56,22 +63,35 @@
             />
           </div>
         </div>
-        <button class="profile-update-button" id="openProfileUpdateBtn">
+        <button class="profile-update-button" id="openProfileUpdateBtn" th:if="${user.getNickname().equals(nickname)}">
           프로필 수정
         </button>
       </div>
       <div class="mypage-menu-switch">
-        <button class="my-post-menu-switch">내 피드</button>
+        <button class="my-post-menu-switch" th:text="${user.getNickname().equals(nickname) ? '내 피드' : '피드'}">내 피드</button>
         <button class="like-it-menu-switch">좋아요 누른 피드</button>
-        <button class="hidden-post-menu-switch">숨긴 피드</button>
+        <button class="hidden-post-menu-switch" th:if="${user.getNickname().equals(nickname)}">숨긴 피드</button>
       </div>
-      <div class="new-post-form">
+      <div class="new-post-form" th:if="${user.getNickname().equals(nickname)}">
         <img
             class="user-photo"
             th:src="@{/images/icons/UI-user2.png}"
             alt="user icon"
         />
         <p id="openPostFormModalBtn">함께 나누고픈 감정이 있나요?</p>
+      </div>
+      <div class="modal fade" id="followerModal" tabindex="-1" aria-labelledby="followerModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-body">
+              <ul id="followerList" class="list-group">
+              </ul>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+            </div>
+          </div>
+        </div>
       </div>
       <div th:replace="fragments/modals/profile-update-modal :: profile-update-modal"></div>
       <div th:replace="fragments/modals/new-post-modal :: new-post-modal"></div>


### PR DESCRIPTION
## :mag_right: 작업 내용

> 현재 로그인 한 유저의 닉네임을 세션에서 받아와
> 내 프로필과 다른 사람의 프로필을 조회 할 시 각각 다른 구성을 보여주도록 수정되었습니다.
> 팔로잉과 팔로워가 반대로 되어있던 문제를 해결했습니다.
> 팔로잉과 팔로워 를 클릭하면 해당하는 유저의 닉네임을 가져오고, 닉네임을 클릭 시 해당 유저의 페이지로 이동하도록 하였습니다.


## ⚫️이미지 첨부
타 유저 프로필
![image](https://github.com/user-attachments/assets/2254a4ff-0ff6-4756-ba0a-03c9ec929ae2)
내 프로필
![image](https://github.com/user-attachments/assets/e550d5ff-850f-484c-9ca0-85a9bcd8be4d)
팔로잉
![image](https://github.com/user-attachments/assets/9b99e7a2-3860-4ac4-adf4-ad6e80dafbc6)
팔로워
![image](https://github.com/user-attachments/assets/79135f8e-fccd-4a81-a81c-7851c9f9c002)



## :heavy_plus_sign: 이슈 링크
#89 

## 기타 사항
이미 숨겨진 게시글에도 숨기기 메뉴가 나오도록 해야할까요?