### PR TITLE
[ FEAT ] 알림 실시간 소켓 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/finalproject/manitoone/aop/AlarmHandler.java
+++ b/src/main/java/com/finalproject/manitoone/aop/AlarmHandler.java
@@ -1,8 +1,15 @@
 package com.finalproject.manitoone.aop;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.finalproject.manitoone.domain.Notification;
+import com.finalproject.manitoone.domain.dto.NotificationResponseDto;
+import com.finalproject.manitoone.dto.user.UserInformationResponseDto;
+import com.finalproject.manitoone.util.DataUtil;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -10,19 +17,24 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 @Component
+@RequiredArgsConstructor
 public class AlarmHandler extends TextWebSocketHandler {
+
+  private final DataUtil dataUtil;
 
   private static final Map<String, WebSocketSession> userSessions = new ConcurrentHashMap<>();
 
   //클라이언트가 서버에 접속 성공시 호출
   @Override
   public void afterConnectionEstablished(WebSocketSession session) {
-
+    System.out.println("소켓 호출했다");
   }
 
   //소켓에 메세지를 보냈을 때 호출
   @Override
-  protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+  protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+    System.out.println("소켓! 연결!");
+    System.out.println(message.getPayload());
     String payload = message.getPayload(); // 클라이언트가 보낸 메시지 (예: 이메일 또는 고유 ID)
 
     // 사용자 ID와 세션 매핑
@@ -36,13 +48,48 @@ public class AlarmHandler extends TextWebSocketHandler {
     userSessions.values().removeIf(s -> s.equals(session));
   }
 
-  public void sendNotification(String email, String message) throws IOException {
+  public void sendMessage(String email, String message) throws IOException {
     // email에 해당하는 WebSocketSession 가져오기
     WebSocketSession session = userSessions.get(email);
 
     // 세션이 유효한 경우 메시지 전송
     if (session != null && session.isOpen()) {
       session.sendMessage(new TextMessage(message)); // 메시지 전송
+    }
+  }
+
+  public void sendNotification(Notification notification) throws IOException {
+    // email에 해당하는 WebSocketSession 가져오기
+    WebSocketSession session = userSessions.get(notification.getUser().getEmail());
+
+    // 세션이 유효한 경우 메시지 전송
+    if (session != null && session.isOpen()) {
+      // NotificationResponseDto 객체 생성
+      NotificationResponseDto notificationResponseDto = NotificationResponseDto.builder()
+          .notiId(notification.getNotiId())
+          .relatedObjectId(notification.getRelatedObjectId())
+          .isRead(notification.getIsRead())
+          .createdAt(notification.getCreatedAt())
+          .user(new UserInformationResponseDto(notification.getUser().getName(),
+              notification.getUser().getNickname(),
+              notification.getUser().getIntroduce(), notification.getUser().getProfileImage()))
+          .senderUser(new UserInformationResponseDto(notification.getSenderUser().getName(),
+              notification.getSenderUser().getNickname(),
+              notification.getSenderUser().getIntroduce(),
+              notification.getSenderUser().getProfileImage()))
+          .timeDifference(dataUtil.getTimeDifference(notification.getCreatedAt()))
+          .type(notification.getType())
+          .content(notification.getType().getMessage(notification.getSenderUser().getNickname()))
+          .build();
+
+      // JSON 변환
+      ObjectMapper objectMapper = new ObjectMapper();
+      objectMapper.registerModule(new JavaTimeModule()); // JSR310 모듈 등록
+
+      String jsonMessage = objectMapper.writeValueAsString(notificationResponseDto);
+
+      // WebSocket 메시지 전송
+      session.sendMessage(new TextMessage(jsonMessage));
     }
   }
 }

--- a/src/main/java/com/finalproject/manitoone/aop/AlarmHandler.java
+++ b/src/main/java/com/finalproject/manitoone/aop/AlarmHandler.java
@@ -1,0 +1,48 @@
+package com.finalproject.manitoone.aop;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+public class AlarmHandler extends TextWebSocketHandler {
+
+  private static final Map<String, WebSocketSession> userSessions = new ConcurrentHashMap<>();
+
+  //클라이언트가 서버에 접속 성공시 호출
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) {
+
+  }
+
+  //소켓에 메세지를 보냈을 때 호출
+  @Override
+  protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    String payload = message.getPayload(); // 클라이언트가 보낸 메시지 (예: 이메일 또는 고유 ID)
+
+    // 사용자 ID와 세션 매핑
+    userSessions.put(payload, session); // payload = 이메일 또는 사용자 ID
+  }
+
+  // 연결이 종료됐을 때 호출
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+    // 세션 제거
+    userSessions.values().removeIf(s -> s.equals(session));
+  }
+
+  public void sendNotification(String email, String message) throws IOException {
+    // email에 해당하는 WebSocketSession 가져오기
+    WebSocketSession session = userSessions.get(email);
+
+    // 세션이 유효한 경우 메시지 전송
+    if (session != null && session.isOpen()) {
+      session.sendMessage(new TextMessage(message)); // 메시지 전송
+    }
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/config/WebSocketConfig.java
+++ b/src/main/java/com/finalproject/manitoone/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.finalproject.manitoone.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    // 클라이언트에서 구독할 prefix 설정
+    config.enableSimpleBroker("/topic"); // 브로커 경로
+    // 클라이언트에서 메시지 보낼 때의 prefix
+    config.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // WebSocket 연결을 위한 엔드포인트 설정
+    registry.addEndpoint("/ws") // 엔드포인트 URL
+        .setAllowedOriginPatterns("http://localhost:8080")
+        .withSockJS(); // SockJS 사용
+  }
+}

--- a/src/main/java/com/finalproject/manitoone/config/WebSocketConfig.java
+++ b/src/main/java/com/finalproject/manitoone/config/WebSocketConfig.java
@@ -1,28 +1,24 @@
 package com.finalproject.manitoone.config;
 
+import com.finalproject.manitoone.aop.AlarmHandler;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
 @Configuration
-@EnableWebSocketMessageBroker
-public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
 
-  @Override
-  public void configureMessageBroker(MessageBrokerRegistry config) {
-    // 클라이언트에서 구독할 prefix 설정
-    config.enableSimpleBroker("/topic"); // 브로커 경로
-    // 클라이언트에서 메시지 보낼 때의 prefix
-    config.setApplicationDestinationPrefixes("/app");
+  private final AlarmHandler alarmHandler;
+
+  public WebSocketConfig(AlarmHandler alarmHandler) {
+    this.alarmHandler = alarmHandler;
   }
 
   @Override
-  public void registerStompEndpoints(StompEndpointRegistry registry) {
-    // WebSocket 연결을 위한 엔드포인트 설정
-    registry.addEndpoint("/ws") // 엔드포인트 URL
-        .setAllowedOriginPatterns("http://localhost:8080")
-        .withSockJS(); // SockJS 사용
+  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+    registry.addHandler(alarmHandler, "/ws-alarm")
+        .setAllowedOrigins("*"); // 필요한 경우 허용된 Origin 설정
   }
 }

--- a/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
+++ b/src/main/java/com/finalproject/manitoone/constants/IllegalActionMessages.java
@@ -31,7 +31,9 @@ public enum IllegalActionMessages {
   EMAIL_VERIFICATION_CODE_MISMATCH("이메일 인증번호가 일치하지 않습니다."),
   INVALID_EMAIL_OR_PASSWORD("이메일 및 비밀번호가 일치하지 않습니다."),
   FAILED_LOGIN("로그인에 실패했습니다."),
-  FAILED_LOGOUT("로그아웃에 실패했습니다.");
+  FAILED_LOGOUT("로그아웃에 실패했습니다."),
+
+  UNAUTORIZED("권한이 없습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/finalproject/manitoone/controller/api/NotificationApiController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/NotificationApiController.java
@@ -7,9 +7,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/api")
+@RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class NotificationApiController {
 

--- a/src/main/java/com/finalproject/manitoone/controller/api/NotificationApiController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/NotificationApiController.java
@@ -21,6 +21,12 @@ public class NotificationApiController {
     return ResponseEntity.ok().build();
   }
 
+  @PutMapping("/notification")
+  public ResponseEntity<Object> readAllNotification(HttpServletRequest request) {
+    notificationService.readAllNotifications(request.getSession());
+    return ResponseEntity.ok().build();
+  }
+
   @GetMapping("/notifications/status")
   public ResponseEntity<Object> checkUnreadNotifications(HttpServletRequest request) {
     return ResponseEntity.ok(notificationService.hasUnreadNotifications(

--- a/src/main/java/com/finalproject/manitoone/controller/api/NotificationApiController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/NotificationApiController.java
@@ -4,6 +4,7 @@ import com.finalproject.manitoone.service.NotificationService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,5 +19,11 @@ public class NotificationApiController {
   public ResponseEntity readNotification(@PathVariable Long notiId, HttpServletRequest request) {
     notificationService.readNotification(notiId, request.getSession());
     return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/notifications/status")
+  public ResponseEntity<Object> checkUnreadNotifications(HttpServletRequest request) {
+    return ResponseEntity.ok(notificationService.hasUnreadNotifications(
+        (String) request.getSession().getAttribute("email")));
   }
 }

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -57,9 +57,9 @@ public class UserAuthController {
       session.setAttribute("profileImage", responseDto.getProfileImage());
       session.setAttribute("introduce", responseDto.getIntroduce());
 
-      // 읽지 않은 알림이 있는지 가져오기
-      session.setAttribute("isRead", notificationService.hasUnreadNotifications(
-          responseDto.getUserId()));
+      // 알림
+      responseDto.setIsRead(notificationService.hasUnreadNotifications(
+          responseDto.getEmail()));
 
       return ResponseEntity.ok(responseDto);
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -5,6 +5,7 @@ import com.finalproject.manitoone.domain.dto.UserLoginRequestDto;
 import com.finalproject.manitoone.domain.dto.UserLoginResponseDto;
 import com.finalproject.manitoone.domain.dto.UserSignUpDTO;
 import com.finalproject.manitoone.service.CustomOAuth2UserService;
+import com.finalproject.manitoone.service.NotificationService;
 import com.finalproject.manitoone.service.UserAuthService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -24,6 +25,7 @@ public class UserAuthController {
 
   private final UserAuthService userAuthService;
   private final CustomOAuth2UserService customOAuth2UserService;
+  private final NotificationService notificationService;
 
   @PostMapping("/signup")
   public ResponseEntity<String> signUp(
@@ -54,6 +56,10 @@ public class UserAuthController {
       session.setAttribute("nickname", responseDto.getNickname());
       session.setAttribute("profileImage", responseDto.getProfileImage());
       session.setAttribute("introduce", responseDto.getIntroduce());
+
+      // 읽지 않은 알림이 있는지 가져오기
+      session.setAttribute("isRead", notificationService.hasUnreadNotifications(
+          responseDto.getUserId()));
 
       return ResponseEntity.ok(responseDto);
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -58,7 +58,7 @@ public class UserAuthController {
       session.setAttribute("introduce", responseDto.getIntroduce());
 
       // 알림
-      responseDto.setIsRead(notificationService.hasUnreadNotifications(
+      responseDto.setRead(notificationService.hasUnreadNotifications(
           responseDto.getEmail()));
 
       return ResponseEntity.ok(responseDto);

--- a/src/main/java/com/finalproject/manitoone/controller/view/NotificationViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/NotificationViewController.java
@@ -18,7 +18,6 @@ public class NotificationViewController {
   @GetMapping
   public String getNotifications(Model model, HttpServletRequest request) {
     model.addAttribute("notifications", notificationService.getAllUnReadNotifications(request.getSession()));
-    request.getSession().setAttribute("isRead", true);
     return "/pages/notifications";
   }
 }

--- a/src/main/java/com/finalproject/manitoone/controller/view/NotificationViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/NotificationViewController.java
@@ -18,6 +18,7 @@ public class NotificationViewController {
   @GetMapping
   public String getNotifications(Model model, HttpServletRequest request) {
     model.addAttribute("notifications", notificationService.getAllUnReadNotifications(request.getSession()));
+    request.getSession().setAttribute("isRead", true);
     return "/pages/notifications";
   }
 }

--- a/src/main/java/com/finalproject/manitoone/controller/view/NotificationViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/NotificationViewController.java
@@ -17,6 +17,9 @@ public class NotificationViewController {
 
   @GetMapping
   public String getNotifications(Model model, HttpServletRequest request) {
+    if (request.getSession() == null || request.getSession().getAttribute("email") == null) {
+      return "redirect:/login";
+    }
     model.addAttribute("notifications", notificationService.getAllUnReadNotifications(request.getSession()));
     return "/pages/notifications";
   }

--- a/src/main/java/com/finalproject/manitoone/domain/Notification.java
+++ b/src/main/java/com/finalproject/manitoone/domain/Notification.java
@@ -49,6 +49,10 @@ public class Notification {
   @Builder.Default
   private LocalDateTime createdAt = LocalDateTime.now();
 
+  @ManyToOne
+  @JoinColumn(name = "sender_user_id", nullable = false)
+  private User senderUser;
+
   public void markAsRead() {
     this.isRead = true;
   }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/AddNotificationRequestDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/AddNotificationRequestDto.java
@@ -23,6 +23,7 @@ public class AddNotificationRequestDto {
     return Notification.builder()
         .user(this.receiveUser)
         .type(this.type)
+        .senderUser(sendUser)
         .relatedObjectId(this.relatedObjectId)
         .build();
   }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/NotificationResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/NotificationResponseDto.java
@@ -18,6 +18,7 @@ public class NotificationResponseDto {
 
   private Long notiId;
   private UserInformationResponseDto user;
+  private UserInformationResponseDto senderUser;
   private NotiType type;
   @Setter
   private String content;

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginResponseDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -18,6 +20,7 @@ public class UserLoginResponseDto {
   private String nickname;
   private String profileImage;
   private String introduce;
+  private boolean isRead;
 
   public UserLoginResponseDto(User user) {
     this.userId = user.getUserId();

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserLoginResponseDto.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UserLoginResponseDto {
 
+  private Long userId;
   private String email;
   private String name;
   private String nickname;
@@ -19,6 +20,7 @@ public class UserLoginResponseDto {
   private String introduce;
 
   public UserLoginResponseDto(User user) {
+    this.userId = user.getUserId();
     this.email = user.getEmail();
     this.name = user.getName();
     this.nickname = user.getNickname();

--- a/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
@@ -12,4 +12,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
   List<Notification> findByUserAndCreatedAtAfterOrderByCreatedAtDesc(User user, LocalDateTime thirtyDaysAgo);
   boolean existsByUserUserIdAndIsRead(Long userId, Boolean isRead);
+  List<Notification> findByUserAndIsReadFalse(User user);
 }

--- a/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
   List<Notification> findByIsReadAndUserOrderByNotiIdDesc(Boolean isRead, User user);
+  boolean existsByUserUserIdAndIsRead(Long userId, Boolean isRead);
 }

--- a/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.finalproject.manitoone.repository;
 
 import com.finalproject.manitoone.domain.Notification;
 import com.finalproject.manitoone.domain.User;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-  List<Notification> findByIsReadAndUserOrderByNotiIdDesc(Boolean isRead, User user);
+  List<Notification> findByUserAndCreatedAtAfterOrderByCreatedAtDesc(User user, LocalDateTime thirtyDaysAgo);
   boolean existsByUserUserIdAndIsRead(Long userId, Boolean isRead);
 }

--- a/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
@@ -11,6 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
   List<Notification> findByUserAndCreatedAtAfterOrderByCreatedAtDesc(User user, LocalDateTime thirtyDaysAgo);
-  boolean existsByUserUserIdAndIsRead(Long userId, Boolean isRead);
+  boolean existsByUserEmailAndIsRead(String email, Boolean isRead);
   List<Notification> findByUserAndIsReadFalse(User user);
 }

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -61,10 +61,21 @@ public class NotificationService {
         .toList();
   }
 
-  public void readAllNotifications(User user) {
+  // 알림 읽음 모두 처리
+  public void readAllNotifications(HttpSession session) {
+    User user = (User) session.getAttribute("user");
+    if (user == null) {
+      throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
+    }
     List<Notification> notifications = notificationRepository.findByUserAndIsReadFalse(user);
-    notifications.forEach(Notification::markAsRead);
-    notificationRepository.saveAll(notifications);
+    if (!notifications.isEmpty()) {
+      notifications.forEach(notification -> {
+        if (user.getNickname().equals(notification.getUser().getNickname())) {
+          notification.markAsRead();
+        }
+      });
+      notificationRepository.saveAll(notifications);
+    }
   }
 
   // 알림 읽음 단일 처리
@@ -81,9 +92,6 @@ public class NotificationService {
     notification.markAsRead();
     notificationRepository.save(notification);
   }
-
-  // 알림 읽음 모두 처리
-
 
   public boolean hasUnreadNotifications(String email) {
     return notificationRepository.existsByUserEmailAndIsRead(email, false);

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -85,7 +85,7 @@ public class NotificationService {
   // 알림 읽음 모두 처리
 
 
-  public boolean hasUnreadNotifications(Long userId) {
-    return notificationRepository.existsByUserUserIdAndIsRead(userId, false);
+  public boolean hasUnreadNotifications(String email) {
+    return notificationRepository.existsByUserEmailAndIsRead(email, false);
   }
 }

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -66,6 +66,6 @@ public class NotificationService {
   }
 
   public boolean hasUnreadNotifications(Long userId) {
-    notificationRepository.existsByUserUserIdAndIsRead(userId, false);
+    return notificationRepository.existsByUserUserIdAndIsRead(userId, false);
   }
 }

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -61,13 +61,13 @@ public class NotificationService {
         .toList();
   }
 
-  // 알림 읽음 단일 처리
   public void readAllNotifications(User user) {
     List<Notification> notifications = notificationRepository.findByUserAndIsReadFalse(user);
     notifications.forEach(Notification::markAsRead);
     notificationRepository.saveAll(notifications);
   }
 
+  // 알림 읽음 단일 처리
   public void readNotification(Long notiId, HttpSession session) {
     User user = (User) session.getAttribute("user");
     if (user == null) {

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -1,5 +1,6 @@
 package com.finalproject.manitoone.service;
 
+import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.domain.Notification;
 import com.finalproject.manitoone.domain.User;
 import com.finalproject.manitoone.domain.dto.NotificationResponseDto;
@@ -21,7 +22,13 @@ public class NotificationService {
   private final DataUtil dataUtil;
 
   public List<NotificationResponseDto> getAllUnReadNotifications(HttpSession session) {
-    User user = (User) session.getAttribute("user");
+    String email;
+    if (session.getAttribute("email") == null) {
+      throw new IllegalArgumentException("권한이 없습니다.");
+    }
+    email = (String) session.getAttribute("email");
+    User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException(
+        IllegalActionMessages.USER_NOT_FOUND.getMessage()));
     if (user == null) {
       throw new IllegalArgumentException("권한이 없습니다.");
     }

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -34,6 +34,11 @@ public class NotificationService {
     if (user == null) {
       throw new IllegalArgumentException("권한이 없습니다.");
     }
+
+    // 모든 알림 읽음 처리
+    // fixme: 테스트를 위해 잠시 주석
+//    readAllNotifications(user);
+
     LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
 
     return notificationRepository.findByUserAndCreatedAtAfterOrderByCreatedAtDesc(user,
@@ -56,6 +61,13 @@ public class NotificationService {
         .toList();
   }
 
+  // 알림 읽음 단일 처리
+  public void readAllNotifications(User user) {
+    List<Notification> notifications = notificationRepository.findByUserAndIsReadFalse(user);
+    notifications.forEach(Notification::markAsRead);
+    notificationRepository.saveAll(notifications);
+  }
+
   public void readNotification(Long notiId, HttpSession session) {
     User user = (User) session.getAttribute("user");
     if (user == null) {
@@ -69,6 +81,9 @@ public class NotificationService {
     notification.markAsRead();
     notificationRepository.save(notification);
   }
+
+  // 알림 읽음 모두 처리
+
 
   public boolean hasUnreadNotifications(Long userId) {
     return notificationRepository.existsByUserUserIdAndIsRead(userId, false);

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -64,4 +64,8 @@ public class NotificationService {
     notification.markAsRead();
     notificationRepository.save(notification);
   }
+
+  public boolean hasUnreadNotifications(Long userId) {
+    notificationRepository.existsByUserUserIdAndIsRead(userId, false);
+  }
 }

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -63,10 +63,12 @@ public class NotificationService {
 
   // 알림 읽음 모두 처리
   public void readAllNotifications(HttpSession session) {
-    User user = (User) session.getAttribute("user");
-    if (user == null) {
+    String email = (String) session.getAttribute("email");
+    if (email == null) {
       throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
     }
+    User user = userRepository.findByEmail(email).orElseThrow(
+        () -> new IllegalArgumentException(IllegalActionMessages.USER_NOT_FOUND.getMessage()));
     List<Notification> notifications = notificationRepository.findByUserAndIsReadFalse(user);
     if (!notifications.isEmpty()) {
       notifications.forEach(notification -> {
@@ -80,10 +82,12 @@ public class NotificationService {
 
   // 알림 읽음 단일 처리
   public void readNotification(Long notiId, HttpSession session) {
-    User user = (User) session.getAttribute("user");
-    if (user == null) {
+    String email = (String) session.getAttribute("email");
+    if (email == null) {
       throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
     }
+    User user = userRepository.findByEmail(email).orElseThrow(
+        () -> new IllegalArgumentException(IllegalActionMessages.USER_NOT_FOUND.getMessage()));
     Notification notification = notificationRepository.findById(notiId)
         .orElseThrow(() -> new IllegalArgumentException("알림이 존재하지 않습니다."));
     if (!user.getNickname().equals(notification.getUser().getNickname())) {

--- a/src/main/java/com/finalproject/manitoone/service/NotificationService.java
+++ b/src/main/java/com/finalproject/manitoone/service/NotificationService.java
@@ -26,13 +26,13 @@ public class NotificationService {
   public List<NotificationResponseDto> getAllUnReadNotifications(HttpSession session) {
     String email;
     if (session.getAttribute("email") == null) {
-      throw new IllegalArgumentException("권한이 없습니다.");
+      throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
     }
     email = (String) session.getAttribute("email");
     User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException(
         IllegalActionMessages.USER_NOT_FOUND.getMessage()));
     if (user == null) {
-      throw new IllegalArgumentException("권한이 없습니다.");
+      throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
     }
 
     // 모든 알림 읽음 처리
@@ -71,12 +71,12 @@ public class NotificationService {
   public void readNotification(Long notiId, HttpSession session) {
     User user = (User) session.getAttribute("user");
     if (user == null) {
-      throw new IllegalArgumentException("권한이 없습니다.");
+      throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
     }
     Notification notification = notificationRepository.findById(notiId)
         .orElseThrow(() -> new IllegalArgumentException("알림이 존재하지 않습니다."));
     if (!user.getNickname().equals(notification.getUser().getNickname())) {
-      throw new IllegalArgumentException("권한이 없습니다.");
+      throw new IllegalArgumentException(IllegalActionMessages.UNAUTORIZED.getMessage());
     }
     notification.markAsRead();
     notificationRepository.save(notification);

--- a/src/main/java/com/finalproject/manitoone/util/NotificationUtil.java
+++ b/src/main/java/com/finalproject/manitoone/util/NotificationUtil.java
@@ -43,8 +43,7 @@ public class NotificationUtil {
         .type(type)
         .relatedObjectId(relatedObjectId)
         .build().toEntity());
-
-    alarmHandler.sendNotification(receiveUser.getEmail(), type.getMessage(sendUser.getNickname()));
+    alarmHandler.sendNotification(notification);
     return notification;
   }
 }

--- a/src/main/java/com/finalproject/manitoone/util/NotificationUtil.java
+++ b/src/main/java/com/finalproject/manitoone/util/NotificationUtil.java
@@ -1,5 +1,6 @@
 package com.finalproject.manitoone.util;
 
+import com.finalproject.manitoone.aop.AlarmHandler;
 import com.finalproject.manitoone.constants.NotiType;
 import com.finalproject.manitoone.domain.Notification;
 import com.finalproject.manitoone.domain.User;
@@ -7,6 +8,7 @@ import com.finalproject.manitoone.domain.dto.AddNotificationRequestDto;
 import com.finalproject.manitoone.domain.dto.NotificationResponseDto;
 import com.finalproject.manitoone.repository.NotificationRepository;
 import com.finalproject.manitoone.repository.UserRepository;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,8 +20,10 @@ public class NotificationUtil {
   private final NotificationRepository notificationRepository;
   private final UserRepository userRepository;
 
+  private final AlarmHandler alarmHandler;
+
   /**
-   * 특정 사용자에게 알림을 생성합니다.
+   * 특정 사용자에게 알림을 생성합니다. (소켓을 통한 알림도 발송)
    *
    * @param receiveUserNickname 알림을 받을 사용자의 닉네임 (예: 팔로우를 받은 유저나 게시글의 주인 등)
    * @param sendUser 알림을 보낸 사용자 (예: 게시글에 좋아요를 누르거나 댓글을 작성한 사용자)
@@ -30,13 +34,17 @@ public class NotificationUtil {
   public Notification createNotification(
       String receiveUserNickname,
       User sendUser, NotiType type,
-      Long relatedObjectId) {
-    return notificationRepository.save(AddNotificationRequestDto.builder()
-        .receiveUser(userRepository.findUserByNickname(receiveUserNickname)
-            .orElseThrow(() -> new IllegalArgumentException("해당 닉네임을 가진 유저를 찾을 수 없습니다.")))
+      Long relatedObjectId) throws IOException {
+    User receiveUser = userRepository.findUserByNickname(receiveUserNickname)
+        .orElseThrow(() -> new IllegalArgumentException("해당 닉네임을 가진 유저를 찾을 수 없습니다."));
+    Notification notification = notificationRepository.save(AddNotificationRequestDto.builder()
+        .receiveUser(receiveUser)
         .sendUser(sendUser)
         .type(type)
         .relatedObjectId(relatedObjectId)
         .build().toEntity());
+
+    alarmHandler.sendNotification(receiveUser.getEmail(), type.getMessage(sendUser.getNickname()));
+    return notification;
   }
 }

--- a/src/main/resources/static/script/header.js
+++ b/src/main/resources/static/script/header.js
@@ -1,0 +1,36 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const isRead = localStorage.getItem("isRead");
+  const userEmail = document.querySelector('meta[name="email"]').getAttribute(
+      "content");
+  const notiImage = document.querySelector(".noti-image");
+
+  if (notiImage) {
+    if (isRead === null) {
+      if (userEmail !== "") {
+        // 서버 통신
+        fetch("/notifications/status")
+        .then(response => response.json())
+        .then(data => {
+          const hasUnread = data;
+          localStorage.setItem("isRead", hasUnread);
+          notiImage.src = hasUnread
+              ? "/images/icons/UI-notification2-on.png"
+              : "/images/icons/UI-notification2.png";
+        })
+        .catch(error => {
+          notiImage.src = "/images/icons/UI-notification2.png";
+        });
+      } else {
+        notiImage.src = "/images/icons/UI-notification2.png";
+      }
+    } else {
+      if (isRead) {
+        notiImage.src = "/images/icons/UI-notification2-on.png";
+      } else {
+        notiImage.src = "/images/icons/UI-notification2.png";
+      }
+    }
+  } else {
+    console.error("알림 아이콘을 찾을 수 없습니다.");
+  }
+});

--- a/src/main/resources/static/script/header.js
+++ b/src/main/resources/static/script/header.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", () => {
         notiImage.src = "/images/icons/UI-notification2.png";
       }
     } else {
-      if (isRead) {
+      if (isRead === 'true') {
         notiImage.src = "/images/icons/UI-notification2-on.png";
       } else {
         notiImage.src = "/images/icons/UI-notification2.png";

--- a/src/main/resources/static/script/notification.js
+++ b/src/main/resources/static/script/notification.js
@@ -22,7 +22,30 @@ function handleNotificationClick(notiType, relatedObjectId, nickname) {
   window.location.href = url; // 해당 URL로 이동
 }
 
+function readAllNotification() {
+  // 알림 읽음 처리
+  fetch('/api/notification', {
+    method: 'PUT',
+  })
+  .then(response => {
+    if (response.ok) {
+      localStorage.setItem('isRead', 'false');
+      const notiImage = document.querySelector('.noti-image');
+      if (notiImage) {
+        notiImage.src = '/images/icons/UI-notification2.png';
+      }
+    } else {
+      console.error('알림 읽음 처리 실패');
+    }
+  })
+  .catch(error => {
+    console.error('서버 통신 오류:', error);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  // 알림 모두 읽음 처리
+  readAllNotification();
   // 모든 notification-container에 이벤트 리스너 추가
   const notificationContainers = document.querySelectorAll('.notification-container');
   notificationContainers.forEach(container => {
@@ -30,6 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const type = container.getAttribute('data-type');
       const relatedObjectId = container.getAttribute('data-id');
       const nickname = container.getAttribute('data-nickname');
+
 
       handleNotificationClick(type, relatedObjectId, nickname);
     });

--- a/src/main/resources/static/script/socket.js
+++ b/src/main/resources/static/script/socket.js
@@ -15,7 +15,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const notiImage = document.querySelector(".noti-image");
 
       if (notiImage) {
-        localStorage.setItem("isRead", true);
+        localStorage.setItem("isRead", 'true');
         notiImage.src = "/images/icons/UI-notification2-on.png";
       }
     };

--- a/src/main/resources/static/script/socket.js
+++ b/src/main/resources/static/script/socket.js
@@ -48,6 +48,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // 알림 섹션의 맨 위에 새로운 알림 추가
         notificationSection.prepend(newNotification);
+
+        // **새로운 알림에 클릭 이벤트 리스너 추가**
+        newNotification.addEventListener('click', () => {
+          const type = newNotification.getAttribute('data-type');
+          const relatedObjectId = newNotification.getAttribute('data-id');
+          const nickname = newNotification.getAttribute('data-nickname');
+
+          handleNotificationClick(type, relatedObjectId, nickname);
+        });
       }
     };
 

--- a/src/main/resources/static/script/socket.js
+++ b/src/main/resources/static/script/socket.js
@@ -1,0 +1,29 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const userEmail = document.querySelector('meta[name="email"]').getAttribute("content");
+
+  if (userEmail) {
+    // WebSocket 연결 설정
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const host = window.location.host; // ex: localhost:8080 또는 your-domain.com
+    const webSocket = new WebSocket(`${protocol}//${host}/ws-alarm`);
+
+    webSocket.onopen = () => {
+      webSocket.send(userEmail); // 서버로 사용자 이메일 전송
+    };
+
+    webSocket.onmessage = (e) => {
+      const notiImage = document.querySelector(".noti-image");
+
+      if (notiImage) {
+        localStorage.setItem("isRead", true);
+        notiImage.src = "/images/icons/UI-notification2-on.png";
+      }
+    };
+
+    webSocket.onclose = () => {
+    };
+
+    webSocket.onerror = (error) => {
+    };
+  }
+});

--- a/src/main/resources/static/script/socket.js
+++ b/src/main/resources/static/script/socket.js
@@ -13,10 +13,41 @@ document.addEventListener("DOMContentLoaded", () => {
 
     webSocket.onmessage = (e) => {
       const notiImage = document.querySelector(".noti-image");
+      const notificationSection = document.querySelector(".notification-section");
 
       if (notiImage) {
         localStorage.setItem("isRead", 'true');
         notiImage.src = "/images/icons/UI-notification2-on.png";
+      }
+
+      // 알림 페이지라면 새로운 알림 추가
+      if (notificationSection) {
+        const notificationData = JSON.parse(e.data); // 메시지가 JSON 형식이라 가정
+
+        // 새로운 알림 항목 생성
+        const newNotification = document.createElement("div");
+        newNotification.classList.add("notification-container");
+        newNotification.setAttribute("data-type", notificationData.type);
+        newNotification.setAttribute("data-id", notificationData.relatedObjectId);
+        newNotification.setAttribute("data-nickname", notificationData.senderUser.nickname || "");
+
+        // 알림 내용 구성
+        newNotification.innerHTML = `
+          <img class="user-photo" 
+               src="${notificationData.senderUser.profileImage}" 
+               alt="user icon"/>
+          <div class="notification-content">
+              <span class="notification-description">
+                  ${notificationData.content}
+              </span>
+              <span class="passed-time">
+                  ${notificationData.timeDifference}
+              </span>
+          </div>
+        `;
+
+        // 알림 섹션의 맨 위에 새로운 알림 추가
+        notificationSection.prepend(newNotification);
       }
     };
 

--- a/src/main/resources/static/style/notification.css
+++ b/src/main/resources/static/style/notification.css
@@ -1,3 +1,9 @@
 .notification-container {
   cursor: pointer;
 }
+
+.no-notification-message {
+  padding-left: 30px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}

--- a/src/main/resources/templates/fragments/common/header.html
+++ b/src/main/resources/templates/fragments/common/header.html
@@ -18,8 +18,8 @@
         <!-- 세션에 유저가 있을 때 -->
         <a th:href="@{/noti}">
           <button>
-            <img
-                th:src="${session.isRead != null} ? (${session.isRead} ? @{/images/icons/UI-notification2-on.png} : @{/images/icons/UI-notification2.png}) : @{/images/icons/UI-notification2.png}"
+            <img class="noti-image"
+                th:src="@{/images/icons/UI-notification2.png}"
                 alt="notification"/>
           </button>
         </a>
@@ -28,7 +28,9 @@
         <!-- 세션에 유저가 없을 때 -->
         <a th:href="@{/login}">
           <button>
-            <img th:src="@{/images/icons/UI-notification2.png}" alt="notification"/>
+            <img
+                class="noti-image"
+                th:src="@{/images/icons/UI-notification2.png}" alt="notification"/>
           </button>
         </a>
       </li>
@@ -49,4 +51,10 @@
   <div class="UI-icon-more">
     <img th:src="@{/images/icons/UI-more2.png}" alt="Show-more-options"/>
   </div>
+  <!-- 로그인된 유저의 이메일을 meta 태그로 전달 -->
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1.5.1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+  <meta name="email" th:content="${session.email != null ? session.email : ''}">
+  <script th:src="@{/script/socket.js}"></script>
+  <script th:src="@{/script/header.js}"></script>
 </header>

--- a/src/main/resources/templates/fragments/common/header.html
+++ b/src/main/resources/templates/fragments/common/header.html
@@ -16,9 +16,11 @@
       </li>
       <li class="UI-icon-list" th:if="${session.user != null}">
         <!-- 세션에 유저가 있을 때 -->
+        <!-- 세션에 유저가 있을 때 -->
         <a th:href="@{/noti}">
           <button>
-            <img th:src="@{/images/icons/UI-notification2.png}" alt="notification" />
+            <!-- isRead 값에 따라 다른 이미지를 표시 -->
+            <img th:src="${session.isRead} ? @{/images/icons/UI-notification2-on.png} : @{/images/icons/UI-notification2.png}" alt="notification" />
           </button>
         </a>
       </li>

--- a/src/main/resources/templates/fragments/common/header.html
+++ b/src/main/resources/templates/fragments/common/header.html
@@ -14,8 +14,7 @@
           /></button>
         </a>
       </li>
-      <li class="UI-icon-list" th:if="${session.user != null}">
-        <!-- 세션에 유저가 있을 때 -->
+      <li class="UI-icon-list" th:if="${session.email != null}">
         <!-- 세션에 유저가 있을 때 -->
         <a th:href="@{/noti}">
           <button>
@@ -25,7 +24,7 @@
           </button>
         </a>
       </li>
-      <li class="UI-icon-list" th:if="${session.user == null}">
+      <li class="UI-icon-list" th:if="${session.email == null}">
         <!-- 세션에 유저가 없을 때 -->
         <a th:href="@{/login}">
           <button>

--- a/src/main/resources/templates/fragments/common/header.html
+++ b/src/main/resources/templates/fragments/common/header.html
@@ -9,9 +9,9 @@
     <ul>
       <li class="UI-icon-list">
         <a th:href="@{/}">
-        <button
-        ><img th:src="@{/images/icons/UI-home2.png}" alt="home"
-        /></button>
+          <button
+          ><img th:src="@{/images/icons/UI-home2.png}" alt="home"
+          /></button>
         </a>
       </li>
       <li class="UI-icon-list" th:if="${session.user != null}">
@@ -19,8 +19,9 @@
         <!-- 세션에 유저가 있을 때 -->
         <a th:href="@{/noti}">
           <button>
-            <!-- isRead 값에 따라 다른 이미지를 표시 -->
-            <img th:src="${session.isRead} ? @{/images/icons/UI-notification2-on.png} : @{/images/icons/UI-notification2.png}" alt="notification" />
+            <img
+                th:src="${session.isRead != null} ? (${session.isRead} ? @{/images/icons/UI-notification2-on.png} : @{/images/icons/UI-notification2.png}) : @{/images/icons/UI-notification2.png}"
+                alt="notification"/>
           </button>
         </a>
       </li>
@@ -28,15 +29,15 @@
         <!-- 세션에 유저가 없을 때 -->
         <a th:href="@{/login}">
           <button>
-            <img th:src="@{/images/icons/UI-notification2.png}" alt="notification" />
+            <img th:src="@{/images/icons/UI-notification2.png}" alt="notification"/>
           </button>
         </a>
       </li>
       <li class="UI-icon-list">
         <a th:href="@{/manito}">
-        <button
-        ><img th:src="@{/images/icons/icon-clover2.png}" alt="manito"
-        /></button>
+          <button
+          ><img th:src="@{/images/icons/icon-clover2.png}" alt="manito"
+          /></button>
         </a>
       </li>
       <li class="UI-icon-list">

--- a/src/main/resources/templates/fragments/content/notification.html
+++ b/src/main/resources/templates/fragments/content/notification.html
@@ -15,4 +15,7 @@
             th:text="${notification.timeDifference}"></span>
     </div>
   </div>
+  <div th:if="${notifications == null or notifications.isEmpty()}" class="no-notifications">
+    <p class="no-notification-message">알림이 없습니다.</p>
+  </div>
 </section>

--- a/src/main/resources/templates/fragments/content/notification.html
+++ b/src/main/resources/templates/fragments/content/notification.html
@@ -2,10 +2,10 @@
   <div th:each="notification : ${notifications}" class="notification-container"
        th:data-type="${notification.type}"
        th:data-id="${notification.relatedObjectId}"
-       th:data-nickname="${notification.nickname}">
+       th:data-nickname="${notification.senderUser.nickname}">
     <img class="user-photo"
-         th:if="${notification.user != null and notification.user.profileImage != null}"
-         th:src="${notification.user.profileImage}"
+         th:if="${notification.senderUser != null and notification.senderUser.profileImage != null}"
+         th:src="${notification.senderUser.profileImage}"
          alt="user icon"/>
     <div class="notification-content">
               <span class="notification-description"

--- a/src/main/resources/templates/pages/auth/sign-in.html
+++ b/src/main/resources/templates/pages/auth/sign-in.html
@@ -106,6 +106,7 @@
       }
     })
     .then(userInfo => {
+      localStorage.setItem("isRead", userInfo.read);
       alert("로그인 성공! 환영합니다.");
       window.location.href = "/";
     })


### PR DESCRIPTION
## :mag_right: 작업 내용

- 로그인시 안 읽은 알림이 있는지 없는지에 대한 boolean Read값 전송합니다. 이후 프론트 로컬스토리지에서 저장합니다.
- 해당 Read의 값으로 알림 이미지 변경
- 알림 페이지 들어갈시 모든 알림 읽음 처리 후 Read값 변경 + 알림 아이콘 변경
- 로그인시 소켓 연결
- 알림을 보낸다면 실시간으로 알림 아이콘 변경
- 알림을 보냈을 때 받는 유저가 알림페이지에 있다면 실시간으로 알림 추가
- 알림을 눌렀을 때 페이지 연결 (게시글 상세, 마니또 페이지는 아직 연결 안됨)


## ⚫️이미지 첨부
![알림성공](https://github.com/user-attachments/assets/fce360cd-8329-497c-b53e-08243cb1a26b)


## :heavy_plus_sign: 이슈 링크

- #93 #95 
