### PR TITLE
알림이 필요한 부분 연결 및 팔로우, 좋아요는 기존 알림 업데이트 방식

### DIFF
--- a/src/main/java/com/finalproject/manitoone/constants/NotiType.java
+++ b/src/main/java/com/finalproject/manitoone/constants/NotiType.java
@@ -7,8 +7,8 @@ public enum NotiType {
   FOLLOW("%s 님이 나를 팔로우했습니다."),
   LIKE_CLOVER("%s 님이 내 게시물에 클로버☘를 보냈습니다."),
   RECEIVE_MANITO("두근두근! 나는 오늘 누구의 마니또가 되었을까요? 게시물을 확인하고 격려와 칭찬을 남기러 가요! "),
-  MANITO_COMMENT("내 게시물에 마니또가 답글을 남겼습니다. 어서 확인해봐요! "),
-  MANITO_THANK_COMMENT("내가 남긴 마니또 답글에 감사인사가 전해졌습니다. 어서 확인해봐요!");
+  MANITO_LETTER("마니또가 편지를 보냈습니다. 어서 확인해봐요! "),
+  MANITO_ANSWER_LETTER("내가 남긴 마니또 편지에 감사인사가 전해졌습니다. 어서 확인해봐요!");
 
   private final String message;
 

--- a/src/main/java/com/finalproject/manitoone/domain/Notification.java
+++ b/src/main/java/com/finalproject/manitoone/domain/Notification.java
@@ -56,4 +56,12 @@ public class Notification {
   public void markAsRead() {
     this.isRead = true;
   }
+
+  public void updateCreatedAt() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  public void unMarkAsRead() {
+    this.isRead = false;
+  }
 }

--- a/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
@@ -16,4 +16,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
   List<Notification> findByUserAndIsReadFalse(User user);
 
   Notification findByUserAndSenderUserAndType(User receiveUser, User senderUser, NotiType type);
+  Notification findByUserAndSenderUserAndTypeAndRelatedObjectId(User receiveUser, User senderUser, NotiType type, Long relatedObjectId);
 }

--- a/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.finalproject.manitoone.repository;
 
+import com.finalproject.manitoone.constants.NotiType;
 import com.finalproject.manitoone.domain.Notification;
 import com.finalproject.manitoone.domain.User;
 import java.time.LocalDateTime;
@@ -13,4 +14,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
   List<Notification> findByUserAndCreatedAtAfterOrderByCreatedAtDesc(User user, LocalDateTime thirtyDaysAgo);
   boolean existsByUserEmailAndIsRead(String email, Boolean isRead);
   List<Notification> findByUserAndIsReadFalse(User user);
+
+  Notification findByUserAndSenderUserAndType(User receiveUser, User senderUser, NotiType type);
 }

--- a/src/main/java/com/finalproject/manitoone/service/ManitoService.java
+++ b/src/main/java/com/finalproject/manitoone/service/ManitoService.java
@@ -75,7 +75,7 @@ public class ManitoService {
     ManitoLetter savedLetter = manitoLetterRepository.save(manitoLetter);
 
     try {
-      notificationUtil.createNotification(match.getMatchedPostId().getUser().getNickname(), user, NotiType.MANITO_COMMENT,
+      notificationUtil.createNotification(match.getMatchedPostId().getUser().getNickname(), user, NotiType.MANITO_LETTER,
           manitoLetter.getManitoLetterId());
     } catch (IOException e) {
       log.error(e.getMessage());
@@ -180,7 +180,7 @@ public class ManitoService {
     manitoLetter.addAnswer(answerLetter, userNickname);
 
     try {
-      notificationUtil.createNotification(manitoLetter.getLetterWriter().getNickname(), manitoLetter.getLetterReceiver(), NotiType.MANITO_THANK_COMMENT,
+      notificationUtil.createNotification(manitoLetter.getLetterWriter().getNickname(), manitoLetter.getLetterReceiver(), NotiType.MANITO_ANSWER_LETTER,
           manitoLetter.getManitoLetterId());
     } catch (IOException e) {
       log.error(e.getMessage());

--- a/src/main/java/com/finalproject/manitoone/service/ReplyService.java
+++ b/src/main/java/com/finalproject/manitoone/service/ReplyService.java
@@ -1,6 +1,7 @@
 package com.finalproject.manitoone.service;
 
 import com.finalproject.manitoone.constants.IllegalActionMessages;
+import com.finalproject.manitoone.constants.NotiType;
 import com.finalproject.manitoone.constants.ReportObjectType;
 import com.finalproject.manitoone.domain.Post;
 import com.finalproject.manitoone.domain.ReplyPost;
@@ -17,12 +18,16 @@ import com.finalproject.manitoone.repository.ReplyPostRepository;
 import com.finalproject.manitoone.repository.ReportRepository;
 import com.finalproject.manitoone.repository.UserPostLikeRepository;
 import com.finalproject.manitoone.repository.UserRepository;
+import com.finalproject.manitoone.util.NotificationUtil;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReplyService {
@@ -32,6 +37,8 @@ public class ReplyService {
   private final ReportRepository reportRepository;
   private final UserPostLikeRepository userPostLikeRepository;
   private final UserRepository userRepository;
+
+  private final NotificationUtil notificationUtil;
 
   // 답글 생성
   public ReplyResponseDto createReply(Long postId, AddReplyRequestDto request, String email) {
@@ -48,6 +55,13 @@ public class ReplyService {
         .user(user)
         .content(request.getContent())
         .build());
+
+    try
+    {
+      notificationUtil.createNotification(post.getUser().getNickname(), user, NotiType.POST_REPLY, user.getUserId());
+    } catch (IOException e) {
+      log.error(e.getMessage());
+    }
 
     return ReplyResponseDto.builder()
         .post(reply.getPost())

--- a/src/main/java/com/finalproject/manitoone/service/ReplyService.java
+++ b/src/main/java/com/finalproject/manitoone/service/ReplyService.java
@@ -58,7 +58,7 @@ public class ReplyService {
 
     try {
       notificationUtil.createNotification(post.getUser().getNickname(), user, NotiType.POST_REPLY,
-          user.getUserId());
+          post.getPostId());
     } catch (IOException e) {
       log.error(e.getMessage());
     }
@@ -93,7 +93,7 @@ public class ReplyService {
 
     try {
       notificationUtil.createNotification(parentReply.getUser().getNickname(), user, NotiType.POST_RE_REPLY,
-          user.getUserId());
+          parentReply.getPost().getPostId());
     } catch (IOException e) {
       log.error(e.getMessage());
     }

--- a/src/main/java/com/finalproject/manitoone/service/ReplyService.java
+++ b/src/main/java/com/finalproject/manitoone/service/ReplyService.java
@@ -56,9 +56,9 @@ public class ReplyService {
         .content(request.getContent())
         .build());
 
-    try
-    {
-      notificationUtil.createNotification(post.getUser().getNickname(), user, NotiType.POST_REPLY, user.getUserId());
+    try {
+      notificationUtil.createNotification(post.getUser().getNickname(), user, NotiType.POST_REPLY,
+          user.getUserId());
     } catch (IOException e) {
       log.error(e.getMessage());
     }
@@ -90,6 +90,13 @@ public class ReplyService {
         .content(request.getContent())
         .parentId(parentReply.getReplyPostId())
         .build());
+
+    try {
+      notificationUtil.createNotification(parentReply.getUser().getNickname(), user, NotiType.POST_RE_REPLY,
+          user.getUserId());
+    } catch (IOException e) {
+      log.error(e.getMessage());
+    }
 
     return ReplyResponseDto.builder()
         .post(childReply.getPost())
@@ -183,7 +190,7 @@ public class ReplyService {
     User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException(
         IllegalActionMessages.CANNOT_FIND_USER_WITH_GIVEN_ID.getMessage()
     ));
-    
+
     ReplyPost reply = replyPostRepository.findByReplyPostId(replyId)
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.CANNOT_FIND_REPLY_POST_WITH_GIVEN_ID.getMessage()

--- a/src/main/java/com/finalproject/manitoone/util/NotificationUtil.java
+++ b/src/main/java/com/finalproject/manitoone/util/NotificationUtil.java
@@ -46,4 +46,8 @@ public class NotificationUtil {
     alarmHandler.sendNotification(notification);
     return notification;
   }
+
+  public void sendAlarm(User receiveUser) throws IOException {
+    alarmHandler.sendMessage(receiveUser.getEmail(), "알림");
+  }
 }

--- a/src/main/resources/static/script/notification.js
+++ b/src/main/resources/static/script/notification.js
@@ -11,8 +11,8 @@ function handleNotificationClick(notiType, relatedObjectId, nickname) {
       url = `/profile/${nickname}`;
       break;
     case 'RECEIVE_MANITO':
-    case 'MANITO_COMMENT':
-    case 'MANITO_THANK_COMMENT':
+    case 'MANITO_LETTER':
+    case 'MANITO_ANSWER_LETTER':
       url = `/manito?letterId=` + relatedObjectId + '$tab=received';
       break;
     default:

--- a/src/main/resources/static/script/socket.js
+++ b/src/main/resources/static/script/socket.js
@@ -19,20 +19,22 @@ document.addEventListener("DOMContentLoaded", () => {
         localStorage.setItem("isRead", 'true');
         notiImage.src = "/images/icons/UI-notification2-on.png";
       }
+      if (e.data !== null) {
+        // 알림 페이지라면 새로운 알림 추가
+        if (notificationSection) {
+          const notificationData = JSON.parse(e.data); // 메시지가 JSON 형식이라 가정
 
-      // 알림 페이지라면 새로운 알림 추가
-      if (notificationSection) {
-        const notificationData = JSON.parse(e.data); // 메시지가 JSON 형식이라 가정
+          // 새로운 알림 항목 생성
+          const newNotification = document.createElement("div");
+          newNotification.classList.add("notification-container");
+          newNotification.setAttribute("data-type", notificationData.type);
+          newNotification.setAttribute("data-id",
+              notificationData.relatedObjectId);
+          newNotification.setAttribute("data-nickname",
+              notificationData.senderUser.nickname || "");
 
-        // 새로운 알림 항목 생성
-        const newNotification = document.createElement("div");
-        newNotification.classList.add("notification-container");
-        newNotification.setAttribute("data-type", notificationData.type);
-        newNotification.setAttribute("data-id", notificationData.relatedObjectId);
-        newNotification.setAttribute("data-nickname", notificationData.senderUser.nickname || "");
-
-        // 알림 내용 구성
-        newNotification.innerHTML = `
+          // 알림 내용 구성
+          newNotification.innerHTML = `
           <img class="user-photo" 
                src="${notificationData.senderUser.profileImage}" 
                alt="user icon"/>
@@ -46,17 +48,18 @@ document.addEventListener("DOMContentLoaded", () => {
           </div>
         `;
 
-        // 알림 섹션의 맨 위에 새로운 알림 추가
-        notificationSection.prepend(newNotification);
+          // 알림 섹션의 맨 위에 새로운 알림 추가
+          notificationSection.prepend(newNotification);
 
-        // **새로운 알림에 클릭 이벤트 리스너 추가**
-        newNotification.addEventListener('click', () => {
-          const type = newNotification.getAttribute('data-type');
-          const relatedObjectId = newNotification.getAttribute('data-id');
-          const nickname = newNotification.getAttribute('data-nickname');
+          // **새로운 알림에 클릭 이벤트 리스너 추가**
+          newNotification.addEventListener('click', () => {
+            const type = newNotification.getAttribute('data-type');
+            const relatedObjectId = newNotification.getAttribute('data-id');
+            const nickname = newNotification.getAttribute('data-nickname');
 
-          handleNotificationClick(type, relatedObjectId, nickname);
-        });
+            handleNotificationClick(type, relatedObjectId, nickname);
+          });
+        }
       }
     };
 


### PR DESCRIPTION
## :mag_right: 작업 내용

- 알림이 필요한 부분에 알림 생성 및 소켓 전송을 연결하였습니다.
- 좋아요, 팔로우같은 경우에는 토글 형식이라 취소가 가능하므로 취소했다가 다시 팔로우, 좋아요를 누르는 경우 알림이 중복으로 너무 많이 쌓이는걸 감안해 기존에 해당 알림이 있다면 시간 및 읽음 처리를 다시 업데이트 해주는 방식으로 진행했습니다. 소켓 전송 항상 합니다.


## :heavy_plus_sign: 이슈 링크

- #120 
