### PR TITLE
feat : 각 페이지 별 필요한 보안사항 추가 및 마무리 작업 진행

### DIFF
--- a/src/main/java/com/finalproject/manitoone/aop/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/finalproject/manitoone/aop/CustomAuthenticationSuccessHandler.java
@@ -1,4 +1,4 @@
-package com.finalproject.manitoone.config;
+package com.finalproject.manitoone.aop;
 
 import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.domain.User;

--- a/src/main/java/com/finalproject/manitoone/config/SecurityConfig.java
+++ b/src/main/java/com/finalproject/manitoone/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.finalproject.manitoone.config;
 
+import com.finalproject.manitoone.aop.CustomAuthenticationSuccessHandler;
 import com.finalproject.manitoone.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -19,8 +20,18 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     return http
         .authorizeHttpRequests(custom -> custom
-            // .antMatchers("/admin/"**).hasRole("ADMIN") // 어드민 페이지 생성 및 롤 생성 시 활성화
-            .anyRequest().permitAll()
+                // .antMatchers("/admin/"**).hasRole("ADMIN") // 어드민 페이지 생성 및 롤 생성 시 활성화
+                .requestMatchers("/register", "/register-info", "/login", "/additional-info",
+                    "/find-password", "/find-password-confirm", "/oauth2/authorization/google")
+                .anonymous()  // 익명 사용자만 접근 가능
+                .requestMatchers("/", "/style/**", "/script/**", "/js/**", "/images/**",
+                    "/img/**")  // 정적 리소스
+                .permitAll()
+                .anyRequest().authenticated()
+            // .anyRequest().permitAll()
+        )
+        .exceptionHandling(exceptions -> exceptions
+            .accessDeniedPage("/access-deny")  // 403 에러 발생 시 /access-deny로 리디렉션
         )
         .oauth2Login(oauth2 -> oauth2
             .loginPage("/login")
@@ -29,8 +40,8 @@ public class SecurityConfig {
             .failureUrl("/login-fail")
         )
         .logout(custom -> custom
-            .logoutSuccessUrl("/")
             .invalidateHttpSession(true)
+            .deleteCookies("JSESSIONID")
         )
         .csrf(AbstractHttpConfigurer::disable)
         .build();

--- a/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/api/UserAuthController.java
@@ -41,7 +41,7 @@ public class UserAuthController {
       userAuthService.registerUser(userSignUpDTO);
       return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료됐습니다.");
     } catch (IllegalArgumentException e) {
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
     }
   }
 
@@ -72,8 +72,7 @@ public class UserAuthController {
 
       return ResponseEntity.ok(userResponse);
     } catch (IllegalArgumentException e) {
-      return ResponseEntity.badRequest()
-          .body(new IllegalArgumentException(IllegalActionMessages.USER_NOT_FOUND.getMessage()));
+      return ResponseEntity.badRequest().body(e.getMessage());
     }
   }
 

--- a/src/main/java/com/finalproject/manitoone/controller/view/UserAuthViewController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/view/UserAuthViewController.java
@@ -1,6 +1,5 @@
 package com.finalproject.manitoone.controller.view;
 
-import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -22,16 +21,6 @@ public class UserAuthViewController {
     return "/pages/auth/sign-in";
   }
 
-//  @GetMapping("/")
-//  public String getNewUserStat(HttpSession session) {
-//    Boolean isNewUser = (Boolean) session.getAttribute("isNewUser");
-//
-//    if (Boolean.TRUE.equals(isNewUser)) {
-//      return "/pages/auth/additional-info";
-//    }
-//    return "index";
-//  }
-
   @GetMapping("/additional-info")
   public String getAdditionalInfoPage() {
     return "/pages/auth/additional-info";
@@ -40,5 +29,10 @@ public class UserAuthViewController {
   @GetMapping("/login-fail")
   public String getFailPage() {
     return "/pages/auth/oauth-login-failure";
+  }
+
+  @GetMapping("/access-deny")
+  public String getAccessDenyPage() {
+    return "/pages/auth/access-deny";
   }
 }

--- a/src/main/java/com/finalproject/manitoone/domain/dto/AuthUpdateDto.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/AuthUpdateDto.java
@@ -26,6 +26,7 @@ public class AuthUpdateDto {
 
   @Size(min = 2, max = 10, message = "닉네임은 2~10자리로 설정해야 합니다.")
   @NotBlank(message = "닉네임은 필수 입력값입니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9]{2,10}$", message = "닉네임은 알파벳 대소문자와 숫자만 포함할 수 있습니다.")
   private String nickname;
 
   @NotNull(message = "생년월일은 필수 입력값입니다.")

--- a/src/main/java/com/finalproject/manitoone/domain/dto/PrincipalDetails.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/PrincipalDetails.java
@@ -61,7 +61,7 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
 
   @Override
   public boolean isEnabled() {
-    return true;
+    return this.user.getStatus() == 1;
   }
 
   @Override

--- a/src/main/java/com/finalproject/manitoone/domain/dto/UserSignUpDTO.java
+++ b/src/main/java/com/finalproject/manitoone/domain/dto/UserSignUpDTO.java
@@ -36,6 +36,7 @@ public class UserSignUpDTO {
 
   @Size(min = 2, max = 10, message = "닉네임은 2~10자리로 설정해야 합니다.")
   @NotBlank(message = "닉네임은 필수 입력값입니다.")
+  @Pattern(regexp = "^[a-zA-Z0-9]{2,10}$", message = "닉네임은 알파벳 대소문자와 숫자만 포함할 수 있습니다.")
   private String nickname;
 
   @NotNull(message = "생년월일은 필수 입력값입니다.")

--- a/src/main/java/com/finalproject/manitoone/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/finalproject/manitoone/service/CustomOAuth2UserService.java
@@ -4,11 +4,9 @@ import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.domain.User;
 import com.finalproject.manitoone.domain.dto.AuthUpdateDto;
 import com.finalproject.manitoone.domain.dto.PrincipalDetails;
-import com.finalproject.manitoone.domain.dto.UserSignUpDTO;
 import com.finalproject.manitoone.repository.UserRepository;
 import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +37,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     String name = oAuth2User.getAttribute("name");
     String password = UUID.randomUUID().toString();
 
-    // todo : 이미 이메일이 존재하는 유저 == 로그인을 1회 이상 한 사람이기 때문에 isNewUser를 False 처리
     boolean isNewUser = userRepository.findByEmail(email).isEmpty();
 
     User user = userRepository.findByEmail(email)

--- a/src/main/resources/static/script/header.js
+++ b/src/main/resources/static/script/header.js
@@ -34,3 +34,48 @@ document.addEventListener("DOMContentLoaded", () => {
     console.error("알림 아이콘을 찾을 수 없습니다.");
   }
 });
+
+document.addEventListener('DOMContentLoaded', function () {
+  const moreBtn = document.getElementById('more-options-btn');
+  const tooltipMenu = document.getElementById('tooltip-menu');
+  const logoutBtn = document.getElementById('logout-btn');
+
+  // 툴팁 메뉴 토글
+  moreBtn.addEventListener('click', function () {
+    tooltipMenu.classList.toggle('hidden');
+  });
+
+  // 클릭 외 다른 곳 클릭 시 툴팁 닫기
+  document.addEventListener('click', function (event) {
+    if (!moreBtn.contains(event.target) && !tooltipMenu.contains(
+        event.target)) {
+      tooltipMenu.classList.add('hidden');
+    }
+  });
+
+  // 로그아웃 버튼 클릭 이벤트
+  logoutBtn.addEventListener("click", function () {
+    const userConfirmed = confirm("정말 로그아웃 하시겠습니까?");
+    if (userConfirmed === true) {
+      fetch("/logout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded", // Spring Security 기본 설정
+        },
+      })
+      .then((response) => {
+        if (response.ok) {
+          alert("로그아웃에 성공했습니다. 바이바이!");
+          window.location.href = "/login";
+        } else {
+          console.error("로그아웃 실패:", response.status, response.statusText);
+          alert("로그아웃 처리에 실패했습니다. 서버에 문제가 발생했습니다.");
+        }
+      })
+      .catch((error) => {
+        console.error("로그아웃 요청 중 오류 발생:", error);
+        alert("네트워크 오류로 로그아웃을 처리할 수 없습니다.");
+      });
+    }
+  });
+});

--- a/src/main/resources/static/style/tooltip.css
+++ b/src/main/resources/static/style/tooltip.css
@@ -4,6 +4,7 @@
 
 .tooltip {
   position: absolute;
+  text-align: center;
   min-width: 72px;
   top: -60px;
   background: white;

--- a/src/main/resources/static/style/tooltip.css
+++ b/src/main/resources/static/style/tooltip.css
@@ -1,0 +1,31 @@
+.hidden {
+  display: none;
+}
+
+.tooltip {
+  position: absolute;
+  min-width: 72px;
+  top: -60px;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  padding: 6px;
+  z-index: 1000;
+}
+
+.tooltip a button {
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.tooltip a button:hover {
+  background-color: #f5f5f5;
+}
+
+.UI-icon-more {
+  position: relative;
+}

--- a/src/main/resources/templates/fragments/common/header.html
+++ b/src/main/resources/templates/fragments/common/header.html
@@ -1,7 +1,7 @@
 <header class="header-container" th:fragment="header">
   <h1>ManiToOne</h1>
   <div class="UI-icon-logo">
-    <a class="home-link"  th:href="@{/}"
+    <a class="home-link" th:href="@{/}"
     ><img th:src="@{/images/logo/logo.png}" alt="home"
     /></a>
   </div>
@@ -19,8 +19,8 @@
         <a th:href="@{/noti}">
           <button>
             <img class="noti-image"
-                th:src="@{/images/icons/UI-notification2.png}"
-                alt="notification"/>
+                 th:src="@{/images/icons/UI-notification2.png}"
+                 alt="notification"/>
           </button>
         </a>
       </li>
@@ -49,7 +49,12 @@
     </ul>
   </nav>
   <div class="UI-icon-more">
-    <img th:src="@{/images/icons/UI-more2.png}" alt="Show-more-options"/>
+    <button id="more-options-btn">
+      <img th:src="@{/images/icons/UI-more2.png}" alt="Show-more-options"/>
+    </button>
+    <div id="tooltip-menu" class="hidden tooltip">
+        <button id="logout-btn">로그아웃</button>
+    </div>
   </div>
   <!-- 로그인된 유저의 이메일을 meta 태그로 전달 -->
   <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1.5.1/dist/sockjs.min.js"></script>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -15,6 +15,7 @@
     <meta name="user-nickname" th:content="${userNickname}">
     <link rel="stylesheet" th:href="@{/style/reset.css}" />
     <link rel="stylesheet" th:href="@{/style/common.css}" />
+    <link rel="stylesheet" th:href="@{/style/tooltip.css}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/main/resources/templates/pages/auth/access-deny.html
+++ b/src/main/resources/templates/pages/auth/access-deny.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" th:href="@{/style/reset.css}"/>
+  <link rel="stylesheet" th:href="@{/style/common.css}"/>
+  <link rel="stylesheet" th:href="@{/style/email-auth.css}"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
+      rel="stylesheet"
+  />
+  <link rel="icon" type="image/x-icon" th:href="@{/images/favicon/favicon.ico}">
+  <title>ManiToOne</title>
+</head>
+<body>
+<section class="email-auth-section">
+  <div class="logo-box">
+    <img th:src="@{/images/logo/long-logo.png}" alt="ManiToOne logo"/>
+  </div>
+
+  <div class="sign-in-link-container">
+    <p>해당 페이지는 접근할 수 없습니다.</p>
+
+    <p class="sign-in-link">
+      <a href="javascript:history.back()">돌아가기</a>
+    </p>
+  </div>
+</section>
+
+</body>
+</html>

--- a/src/main/resources/templates/pages/auth/additional-info.html
+++ b/src/main/resources/templates/pages/auth/additional-info.html
@@ -143,7 +143,7 @@
     }
 
     if (!nicknameRegex.test(nickname)) {
-      nicknameError.textContent = "닉네임은 2~10자리로 설정해야 합니다.";
+      nicknameError.textContent = "닉네임은 특수문자를 제외한 2~10자리로 설정해야 합니다.";
       if (!firstErrorField) {
         firstErrorField = document.getElementById("user-nickname");
       }

--- a/src/main/resources/templates/pages/auth/additional-info.html
+++ b/src/main/resources/templates/pages/auth/additional-info.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" th:href="@{/style/sign-up.css}"/>
   <link rel="stylesheet" th:href="@{/style/additional-info.css}"/>
   <link rel="stylesheet" th:href="@{/style/loading.css}"/>
+  <link rel="stylesheet" th:href="@{/style/password-view.css}"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link
@@ -30,16 +31,19 @@
       <p id="desc" class="desc">비밀번호, 닉네임, 생년월일을 입력하여 주십시오.</p>
       <div class="sign-up-input-container">
         <br/>
-        <p>비밀번호</p>
-        <input
-            class="sign-up-input"
-            type="password"
-            name="user-password"
-            id="user-password"
-            placeholder="비밀번호(영문 대-소문자, 숫자, 특수문자 포함 8~16자)"
-            aria-label="비밀번호 입력"
-            required
-        />
+        <div class="password-input-container">
+          <input
+              class="sign-up-input"
+              type="password"
+              name="user-password"
+              id="user-password"
+              placeholder="비밀번호(영문 대-소문자, 숫자, 특수문자 포함 8~16자)"
+              aria-label="비밀번호 입력"
+              required
+          />
+          <button type="button" id="toggle-password-sign-up" aria-label="비밀번호 표시/숨기기">표시</button>
+        </div>
+
         <p><span id="password-error" class="error-message"></span></p>
         <p>닉네임</p>
         <input
@@ -183,6 +187,21 @@
     buttonText.style.display = 'inline';
     loadingSpinner.style.display = 'none';
   }
+
+  const togglePasswordButton = document.getElementById("toggle-password-sign-up");
+  const passwordInput = document.getElementById("user-password");
+
+  togglePasswordButton.addEventListener("click", function () {
+    if (passwordInput.type === "password") {
+      passwordInput.type = "text";
+      togglePasswordButton.textContent = "숨기기";
+    } else {
+      passwordInput.type = "password";
+      togglePasswordButton.textContent = "표시";
+    }
+  });
+
+
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/pages/auth/additional-info.html
+++ b/src/main/resources/templates/pages/auth/additional-info.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" th:href="@{/style/common.css}"/>
   <link rel="stylesheet" th:href="@{/style/sign-up.css}"/>
   <link rel="stylesheet" th:href="@{/style/additional-info.css}"/>
+  <link rel="stylesheet" th:href="@{/style/loading.css}"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link
@@ -62,7 +63,10 @@
         />
         <p><span id="birth-error" class="error-message"></span></p>
       </div>
-      <button class="sign-up-button">가입</button>
+      <button id="sign-up-button" class="sign-up-button">
+        <span class="button-text">가입</span>
+        <span id="loading-spinner" class="loading-spinner" style="display: none;"></span>
+      </button>
     </form>
   </div>
   <div class="sign-in-link-container">
@@ -86,6 +90,12 @@
     passwordError.textContent = "";
     nicknameError.textContent = "";
     birthError.textContent = "";
+
+    const signUpButton = document.getElementById("sign-up-button");
+    const buttonText = signUpButton.querySelector('.button-text');
+    const loadingSpinner = signUpButton.querySelector('#loading-spinner');
+    buttonText.style.display = 'none';
+    loadingSpinner.style.display = 'inline-block';
 
     const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
     const nicknameRegex = /^.{2,10}$/;
@@ -127,6 +137,7 @@
       if (firstErrorField) {
         firstErrorField.focus();
       }
+      resetButtonState();
       return;
     }
 
@@ -158,8 +169,20 @@
     })
     .catch(error => {
       alert('추가 정보 입력 실패: ' + error.message);
-    });
+    })
+    .finally(() => {
+      resetButtonState();
+    })
   });
+
+  function resetButtonState() {
+    const signUpButton = document.getElementById('sign-up-button');
+    const buttonText = signUpButton.querySelector('.button-text');
+    const loadingSpinner = signUpButton.querySelector('#loading-spinner');
+
+    buttonText.style.display = 'inline';
+    loadingSpinner.style.display = 'none';
+  }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/pages/auth/additional-info.html
+++ b/src/main/resources/templates/pages/auth/additional-info.html
@@ -56,6 +56,7 @@
             required
         />
         <p><span id="nickname-error" class="error-message"></span></p>
+
         <p>생년월일</p>
         <input
             class="sign-up-input"
@@ -80,6 +81,32 @@
 </section>
 
 <script>
+  document.getElementById("user-nickname").addEventListener("input", function () {
+    const nickname = this.value;
+    const nicknameError = document.getElementById("nickname-error");
+
+    if (nickname.length > 0) {
+      fetch(`/api/check-nickname?nickname=${nickname}`)
+      .then(response => {
+        if (response.ok) {
+          nicknameError.textContent = '사용 가능한 닉네임입니다.';
+          nicknameError.style.color = 'green';
+        } else {
+          return response.text().then(errorText => {
+            nicknameError.textContent = errorText;
+            nicknameError.style.color = 'red';
+          });
+        }
+      })
+      .catch(error => {
+        nicknameError.textContent = '서버 오류가 발생했습니다. 다시 시도해주세요.';
+        nicknameError.style.color = 'red';
+      });
+    } else {
+      nicknameError.textContent = '이미 존재하는 닉네임 입니다.';
+    }
+  });
+
   document.getElementById("sign-up-form").addEventListener("submit", function (event) {
     event.preventDefault();
 
@@ -102,7 +129,7 @@
     loadingSpinner.style.display = 'inline-block';
 
     const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
-    const nicknameRegex = /^.{2,10}$/;
+    const nicknameRegex = /^[a-zA-Z0-9]{2,10}$/;
 
     let isValid = true;
     let firstErrorField = null;
@@ -172,7 +199,7 @@
       window.location.href = "/";
     })
     .catch(error => {
-      alert('추가 정보 입력 실패: ' + error.message);
+      alert('추가 정보 전송에 실패했습니다. 에러 메시지를 확인해주세요.');
     })
     .finally(() => {
       resetButtonState();
@@ -200,7 +227,6 @@
       togglePasswordButton.textContent = "표시";
     }
   });
-
 
 </script>
 </body>

--- a/src/main/resources/templates/pages/auth/find-password.html
+++ b/src/main/resources/templates/pages/auth/find-password.html
@@ -102,9 +102,20 @@
     })
     .catch(error => {
       alert("비밀번호 초기화 실패: " + error.message);
-    });
+    })
+    .finally(() => {
+      resetButtonState();
+    })
   });
 
+  function resetButtonState() {
+    const emailAuthButton = document.getElementById('emailAuthButton');
+    const buttonText = emailAuthButton.querySelector('.button-text');
+    const loadingSpinner = emailAuthButton.querySelector('#emailLoadingSpinner');
+
+    buttonText.style.display = 'inline';
+    loadingSpinner.style.display = 'none';
+  }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/pages/auth/sign-in.html
+++ b/src/main/resources/templates/pages/auth/sign-in.html
@@ -101,9 +101,9 @@
     })
     .then(response => {
       if (response.ok) {
-        return response.json();  // 정상적인 응답은 JSON으로 처리
+        return response.text();  // 정상적인 응답은 JSON으로 처리
       } else {
-        return response.json().then(errorResponse => {
+        return response.text().then(errorResponse => {
           // 오류가 JSON 형태로 반환되면 여기에 처리
           throw new Error(errorResponse.error || "알 수 없는 오류");
         });

--- a/src/main/resources/templates/pages/auth/sign-up.html
+++ b/src/main/resources/templates/pages/auth/sign-up.html
@@ -144,7 +144,7 @@
         nicknameError.style.color = 'red';
       });
     } else {
-      nicknameError.textContent = '';
+      nicknameError.textContent = '이미 존재하는 닉네임 입니다.';
     }
   });
 
@@ -171,7 +171,7 @@
 
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
     const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$/;
-    const nicknameRegex = /^.{2,10}$/;
+    const nicknameRegex = /^[a-zA-Z0-9]{2,10}$/;
 
     let isValid = true;
     let firstErrorField = null;

--- a/src/main/resources/templates/pages/auth/sign-up.html
+++ b/src/main/resources/templates/pages/auth/sign-up.html
@@ -202,7 +202,7 @@
     }
 
     if (!nicknameRegex.test(nickname)) {
-      nicknameError.textContent = "닉네임은 2~10자리로 설정해야 합니다.";
+      nicknameError.textContent = "닉네임은 특수문자를 제외한 2~10자리로 설정해야 합니다.";
       if (!firstErrorField) {
         firstErrorField = document.getElementById("user-nickname");
       }

--- a/src/main/resources/templates/pages/auth/sign-up.html
+++ b/src/main/resources/templates/pages/auth/sign-up.html
@@ -219,11 +219,10 @@
     }
 
     if (!isValid) {
-      // 첫 번째 에러 필드에 포커스 설정
       if (firstErrorField) {
         firstErrorField.focus();
       }
-      return; // API 호출 중단
+      return;
     }
 
     const requestData = {
@@ -262,8 +261,20 @@
     })
     .catch(error => {
       alert('회원가입 실패 : ' + error.message);
-    });
+    })
+    .finally(() => {
+      resetButtonState();
+    })
   });
+
+  function resetButtonState() {
+    const emailAuthButton = document.getElementById('emailAuthButton');
+    const buttonText = emailAuthButton.querySelector('.button-text');
+    const loadingSpinner = emailAuthButton.querySelector('#emailLoadingSpinner');
+
+    buttonText.style.display = 'inline';
+    loadingSpinner.style.display = 'none';
+  }
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/pages/auth/sign-up.html
+++ b/src/main/resources/templates/pages/auth/sign-up.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" th:href="@{/style/common.css}"/>
   <link rel="stylesheet" th:href="@{/style/sign-up.css}"/>
   <link rel="stylesheet" th:href="@{/style/password-view.css}"/>
-  <link rel="stylesheet" th:href="@{/style/password-view.css}"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link


### PR DESCRIPTION
## :mag_right: 작업 내용

- 유저 회원가입 및 로그인과 관련하여 닉네임 유효성 검사를 제한합니다. 
(닉네임에 특수문자가 들어가지 못하도록 수정했습니다.)

- 로그인 한 유저가 로그인, 회원가입, 비밀번호 초기화, OAuth2 로그인 페이지로 돌아갈 수 없도록 수정했습니다.
(만약 로그인을 한 이후 강제적으로 페이지 이동을 하면 자동으로 /access-deny 페이지로 이동하도록 설정했습니다.)

- 헤더에 로그아웃 툴팁을 추가했습니다.


## ⚫️이미지 첨부



## :heavy_plus_sign: 이슈 링크

- [#86]
- [#115]