### PR TITLE
프로필 상세 구현 및 게시물 관련 (좋아요, 숨기기) 기능 개선

### DIFF
--- a/src/main/java/com/finalproject/manitoone/controller/FollowController.java
+++ b/src/main/java/com/finalproject/manitoone/controller/FollowController.java
@@ -17,11 +17,16 @@ public class FollowController {
 
   private final FollowService followService;
 
-  @GetMapping("/{targetNickName}")
+  @GetMapping("/followed/{nickname}")
+  public ResponseEntity<Boolean> isFollowed(@PathVariable String nickname, HttpSession session) {
+    return ResponseEntity.ok().body(followService.isFollowed((String) session.getAttribute("nickname"), nickname));
+  }
+
+  @GetMapping("/{nickname}")
   public ResponseEntity<Void> followUnfollow(
-      @PathVariable String targetNickName, HttpSession session) {
+      @PathVariable String nickname, HttpSession session) {
     if (Boolean.TRUE.equals(
-        followService.toggleFollow((String) session.getAttribute("nickname"), targetNickName))) {
+        followService.toggleFollow((String) session.getAttribute("nickname"), nickname))) {
       return ResponseEntity.status(HttpStatus.CREATED).build();
     } else {
       return ResponseEntity.status(HttpStatus.OK).build();

--- a/src/main/java/com/finalproject/manitoone/repository/UserPostLikeRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/UserPostLikeRepository.java
@@ -16,4 +16,6 @@ public interface UserPostLikeRepository extends JpaRepository<UserPostLike, Long
   Optional<List<UserPostLike>> findAllByPostPostId(Long postId);
 
   Optional<List<UserPostLike>> findAllByReplyPostId(Long replyId);
+
+  Optional<UserPostLike> findByUser_UserIdAndPost_PostId(Long userId, Long postId);
 }

--- a/src/main/java/com/finalproject/manitoone/service/PostService.java
+++ b/src/main/java/com/finalproject/manitoone/service/PostService.java
@@ -3,7 +3,6 @@ package com.finalproject.manitoone.service;
 import com.finalproject.manitoone.constants.IllegalActionMessages;
 import com.finalproject.manitoone.constants.ReportObjectType;
 import com.finalproject.manitoone.domain.AiPostLog;
-import com.finalproject.manitoone.domain.ManitoLetter;
 import com.finalproject.manitoone.domain.ManitoMatches;
 import com.finalproject.manitoone.domain.Post;
 import com.finalproject.manitoone.domain.PostImage;
@@ -31,6 +30,7 @@ import com.finalproject.manitoone.repository.UserRepository;
 import com.finalproject.manitoone.util.AlanUtil;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -234,7 +234,7 @@ public class PostService {
         .orElseThrow(() -> new IllegalArgumentException(
             IllegalActionMessages.CANNOT_FIND_POST_WITH_GIVEN_ID.getMessage()));
 
-    post.hidePost(true);
+    post.hidePost(!Boolean.TRUE.equals(post.getIsHidden()));
 
     postRepository.save(post);
   }
@@ -250,10 +250,16 @@ public class PostService {
             IllegalActionMessages.CANNOT_FIND_POST_WITH_GIVEN_ID.getMessage()
         ));
 
-    userPostLikeRepository.save(UserPostLike.builder()
-        .post(post)
-        .user(user)
-        .build());
+    Optional<UserPostLike> existingLike = userPostLikeRepository.findByUser_UserIdAndPost_PostId(user.getUserId(), post.getPostId());
+
+    if (existingLike.isPresent()) {
+      userPostLikeRepository.delete(existingLike.get());
+    } else {
+      userPostLikeRepository.save(UserPostLike.builder()
+          .post(post)
+          .user(user)
+          .build());
+    }
   }
 
   // 게시글 신고

--- a/src/main/resources/static/script/profile.js
+++ b/src/main/resources/static/script/profile.js
@@ -28,50 +28,58 @@ document.addEventListener("DOMContentLoaded", function () {
 
   loadPosts(pageNum);
 
-  function handleScroll() {
+  async function handleScroll() {
     if (window.innerHeight + window.scrollY >= document.body.scrollHeight
         - 100) {
       if (!isLoading && hasMorePosts) {
         isLoading = true;
         pageNum++;
-        loadPosts(pageNum);
+        await loadPosts(pageNum);
       }
     }
   }
 
-  function switchCategory(category) {
+  async function switchCategory(category) {
     currentCategory = category;
     pageNum = 0;
     hasMorePosts = true;
     postsContainer.innerHTML = '';
-    loadPosts(pageNum);
+    await loadPosts(pageNum);
   }
 
-  function loadPosts(pageNum) {
+  async function loadPosts(pageNum) {
     const apiUrl = getApiUrl(pageNum);
-    fetch(apiUrl)
-    .then(response => response.json())
-    .then(posts => {
+    try {
+      const posts = await fetchPosts(apiUrl);
       if (posts && posts.length > 0) {
-        posts.forEach(post => {
-          const postElement = createPostElement(post);
+        for (const post of posts) {
+          const postElement = await createPostElement(post);
           postsContainer.appendChild(postElement);
-        });
+        }
       } else {
         hasMorePosts = false;
       }
+    } catch (error) {
+      console.error('게시물을 불러오지 못했습니다.:', error);
+    } finally {
       isLoading = false;
-      addFriendButtonsEventListener();
-      addHidePostEventListener();
-      addReportPostEventListener();
-      addDocumentClickEventListener();
-      addPostLikeEventListener();
-      addPostDeleteEventHandler();
-    })
-    .catch(error => {
-      console.error('Error loading posts:', error);
-      isLoading = false;
-    });
+    }
+
+    addFriendButtonsEventListener();
+    addHidePostEventListener();
+    addReportPostEventListener();
+    addDocumentClickEventListener();
+    addPostLikeEventListener();
+    addPostDeleteEventHandler();
+    postContentEventListener();
+  }
+
+  async function fetchPosts(apiUrl) {
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      throw new Error('게시물 목록을 가져오지 못했습니다.');
+    }
+    return response.json();
   }
 
   function getApiUrl(pageNum) {
@@ -84,7 +92,9 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  function createPostElement(post) {
+  async function createPostElement(post) {
+    const isFollowed = await getIsFollowed(post.nickName);
+
     const postElement = document.createElement("div");
     postElement.classList.add("post-container");
 
@@ -92,44 +102,81 @@ document.addEventListener("DOMContentLoaded", function () {
         : timeForToday(post.createdAt);
 
     postElement.innerHTML = `
-          <img class="user-photo" src="${post.profileImage
-    || '/images/icons/UI-user2.png'}" alt="user icon" />
-          <div class="post-content">
-            <div class="user-info">
-              <a href="/profile/${post.nickName}" class="user-name">${post.nickName}</a>
-              <span class="passed-time" data-created-at="${post.createdAt}" data-updated-at="${post.updatedAt}">${timeText}</span>
-            </div>
-            <p class="content-text">${post.content}</p>
-            <div class="reaction-icons">
+        <a href="/profile/${post.nickName}"><img class="user-photo" src="${post.profileImage || '/images/icons/UI-user2.png'}" alt="user icon" /></a>
+        <div class="post-content">
+          <div class="user-info">
+            <a href="/profile/${post.nickName}" class="user-name">${post.nickName}</a>
+            <span class="passed-time" data-created-at="${post.createdAt}" data-updated-at="${post.updatedAt}">${timeText}</span>
+          </div>
+          <p class="content-text" data-post-id="${post.postId}">${post.content}</p>
+          <div class="reaction-icons">
             ${myNickName !== post.nickName
         ? `<img class="tiny-icons" src="/images/icons/icon-clover2.png" alt="I like this" data-post-id="${post.postId}"/>`
         : `<img class="tiny-icons" src="/images/icons/icon-clover2.png" alt="my post"/>`}
-              <span class="like-count">${post.likeCount}</span>
-              <img class="tiny-icons" src="/images/icons/icon-comment2.png" alt="add reply" />
-              <span class="reply-count">${post.replies.length}</span>
-            </div>
+            <span class="like-count">${post.likeCount}</span>
+            <img class="tiny-icons" src="/images/icons/icon-comment2.png" alt="add reply" />
+            <span class="reply-count">${post.replies.length}</span>
           </div>
-          ${currentCategory !== 3 ? `
-          <div class="option-icons">
-            <img class="tiny-icons" src="/images/icons/UI-more2.png" alt="more options" />
-            ${myNickName !== post.nickName
+        </div>
+        ${currentCategory !== 3 ? `
+        <div class="option-icons">
+          <img class="tiny-icons" src="/images/icons/UI-more2.png" alt="more options" />
+          ${myNickName !== post.nickName && !isFollowed
         ? `<img class="tiny-icons" src="/images/icons/icon-add-friend.png" alt="add friend" data-target-id="${post.nickName}"/>`
-        : ''}
-            <div class="more-options-menu hidden">
-              <ul>
-                ${myNickName === post.nickName
+        : ''} 
+          <div class="more-options-menu hidden">
+            <ul>
+              ${myNickName === post.nickName
         ? `
-                    <li><a href="#" class="hide-post" data-post-id="${post.postId}">숨기기</a></li>
-                    <hr>
-                    <li><a href="#" class="delete-post" data-post-id="${post.postId}">삭제하기</a></li>
-                  `
+                  <li><a href="#" class="hide-post" data-post-id="${post.postId}">숨기기</a></li>
+                  <hr>
+                  <li><a href="#" class="delete-post" data-post-id="${post.postId}">삭제하기</a></li>
+                `
         : `<li><a href="#" class="report-post" data-post-id="${post.postId}">신고하기</a></li>`}
-              </ul>
-            </div>
+            </ul>
           </div>
-        ` : ''}
-        `;
+        </div>
+      ` : `
+        <div class="option-icons">
+          <img class="tiny-icons" src="/images/icons/UI-more2.png" alt="more options" />
+          ${myNickName !== post.nickName && !isFollowed
+        ? `<img class="tiny-icons" src="/images/icons/icon-add-friend.png" alt="add friend" data-target-id="${post.nickName}"/>`
+        : ''} 
+          <div class="more-options-menu hidden">
+            <ul>
+              ${myNickName === post.nickName
+        ? `
+                  <li><a href="#" class="hide-post" data-post-id="${post.postId}">숨기기 해제</a></li>
+                  <hr>
+                  <li><a href="#" class="delete-post" data-post-id="${post.postId}">삭제하기</a></li>
+                `
+        : `<li><a href="#" class="report-post" data-post-id="${post.postId}">신고하기</a></li>`}
+            </ul>
+          </div>
+        </div>
+      `}
+      `;
+
     return postElement;
+  }
+
+  async function getIsFollowed(nickName) {
+    try {
+      const response = await fetch(`/api/follow/followed/${nickName}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      const body = await response.text();
+      const isFollowed = body === 'true';
+
+      return isFollowed;
+    } catch (error) {
+      console.error("팔로우 상태를 가져오는데 실패했습니다.:", error);
+      return false;
+    }
   }
 
   function timeForToday(value) {
@@ -179,8 +226,18 @@ document.addEventListener("DOMContentLoaded", function () {
       location.reload();
       button.alt = response.status === 201 ? "remove friend" : "add friend";
     } else {
-      alert("wtf?");
+      alert("how?");
     }
+  }
+
+  function postContentEventListener() {
+    const postContents = document.querySelectorAll('.content-text');
+    postContents.forEach(click => click.addEventListener("click", handlePostContentClick));
+  }
+
+  function handlePostContentClick() {
+    const postId = this.dataset.postId;
+    location.href="/post/" + postId;
   }
 
   postsContainer.addEventListener('click', function (event) {
@@ -206,6 +263,129 @@ document.addEventListener("DOMContentLoaded", function () {
       toggleButton.textContent = "표시";
     }
   });
+
+  const profileImage = document.querySelector("#user-photo");
+  const profileImageInput = document.querySelector("#profile-image-input");
+  const modal = document.querySelector("#image-action-modal");
+  const deletePhotoBtn = document.querySelector("#delete-photo-btn");
+  const uploadPhotoBtn = document.querySelector("#upload-photo-btn");
+  const closeModalBtn = document.querySelector("#close-modal-btn");
+  const modalOverlay = document.querySelector("#modal-overlay");
+
+  function updateProfileImage(file) {
+    const formData = new FormData();
+    formData.append("profileImageFile", file);
+
+    fetch(`/api/user`, {
+      method: "PUT",
+      body: formData,
+    })
+    .then((response) => {
+      if (!response.ok) {
+        return response.text().then((message) => {
+          throw new Error(message);
+        });
+      }
+      return response.json();
+    })
+    .then((updatedUser) => {
+      alert("프로필 이미지가 성공적으로 업데이트되었습니다.");
+      profileImage.src = updatedUser.profileImage;
+    })
+    .catch((error) => {
+      alert(`프로필 이미지 업데이트에 실패했습니다: ${error.message}`);
+    });
+  }
+
+  profileImage.addEventListener("click", () => {
+    modal.style.display = "block";
+    modalOverlay.style.display = "block";
+  });
+
+  const closeModal = () => {
+    modal.style.display = "none";
+    modalOverlay.style.display = "none";
+  };
+
+  closeModalBtn.addEventListener("click", closeModal);
+
+  modalOverlay.addEventListener("click", closeModal);
+
+  deletePhotoBtn.addEventListener("click", () => {
+    // profileImage.src = defaultImageSrc;
+    // profileImageInput.value = "";
+    updateProfileImage(null);
+    closeModal();
+  });
+
+  uploadPhotoBtn.addEventListener("click", () => {
+    profileImageInput.click();
+    closeModal();
+  });
+
+  profileImageInput.addEventListener("change", (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      if (!file.type.startsWith("image/")) {
+        alert("이미지 파일만 선택할 수 있습니다.");
+        profileImageInput.value = "";
+        return;
+      }
+
+      // const reader = new FileReader();
+      //
+      // reader.onload = (e) => {
+      //   profileImage.src = e.target.result;
+      // };
+
+      // reader.readAsDataURL(file);
+      updateProfileImage(file);
+    }
+  });
+
+  const updateProfileButton = document.getElementById('update_profile_button');
+
+  updateProfileButton.addEventListener('click', function () {
+    const nickname = document.getElementById('user-nickname').value;
+    const introduce = document.getElementById('user-introduce').value;
+    const password = document.getElementById('user-password').value;
+
+    if (!nickname || !introduce || !password) {
+      alert("모든 필드를 입력해주세요.");
+      return;
+    }
+
+    const userData = {
+      nickname: nickname,
+      introduce: introduce,
+      password: password
+    };
+
+    fetch('/api/user', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(userData)
+    })
+    .then(response => {
+      if (response.ok) {
+        location.reload();
+        closeProfileUpdateModal();
+      } else {
+        throw new Error('프로필 수정에 실패했습니다.');
+      }
+    })
+    .catch(error => {
+      alert(`오류가 발생했습니다: ${error.message}`);
+    });
+  });
+
+  function closeProfileUpdateModal() {
+    const profileUpdateModal = document.getElementById('profileUpdateModalBackground');
+    profileUpdateModal.style.display = 'none';
+  }
+
 });
 
 function handleMoreOptionsClick(event, moreOptionsButton) {
@@ -272,9 +452,9 @@ function addHidePostEventListener() {
         })
         .then(response => {
           if (response.ok) {
-            alert('게시글이 숨김 처리 되었습니다.');
+            alert('게시글 숨기기 토글이 완료되었습니다.');
           } else {
-            alert('게시글 숨김 처리에 실패했습니다.');
+            alert('게시글 숨기기 토글에 실패했습니다.');
           }
         })
         .catch(error => {
@@ -294,9 +474,6 @@ function addPostLikeEventListener() {
 
   likePostButtons.forEach(button => {
     button.addEventListener('click', function () {
-      if (button.classList.contains('liked')) {
-        return;
-      }
       const postId = this.dataset.postId;
 
       if (postId) {
@@ -305,15 +482,24 @@ function addPostLikeEventListener() {
         })
         .then(response => {
           if (response.status === 200) {
-            const likeCountElement = button.closest('div').querySelector(
-                '.like-count');
+            const likeCountElement = button.closest('div').querySelector('.like-count');
 
             if (likeCountElement) {
-              const currentLikes = parseInt(likeCountElement.textContent, 10);
-              likeCountElement.textContent = currentLikes + 1;
-              button.classList.add('liked');
+              fetch('/api/post/like/number/' + postId)
+              .then(response => response.text())
+              .then(countText => {
+                const currentLikes = parseInt(countText, 10);
+                likeCountElement.textContent = currentLikes;
+                button.classList.add('liked');
+              })
+              .catch(error => {
+                console.error('Error fetching like count:', error);
+              });
             }
           }
+        })
+        .catch(error => {
+          console.error('Error liking the post:', error);
         });
       }
     });
@@ -348,36 +534,88 @@ function addPostDeleteEventHandler() {
 
 function addReportPostEventListener() {
   const reportPostButtons = document.querySelectorAll('.report-post');
+  const reportModal = document.getElementById('reportModal');
+  const reportModalContainer = document.getElementById('reportModalContainer');
+  const closeReportModalButton = document.getElementById('closeReportModalBtn');
+  const reportSendButton = document.getElementById('reportSendBtn');
+  const reportTypeSelect = document.getElementById('report-type-select');
+
+  let isReportButtonClicked = false;
+
   reportPostButtons.forEach(button => {
     button.addEventListener('click', function () {
-      const postId = this.dataset.postId;
+      const postId = button.getAttribute('data-post-id');
+      reportModalContainer.setAttribute('data-post-id', postId);
 
-      if (postId) {
-        fetch('/api/post/report/' + postId, {
-          method: 'PUT',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({postId: postId}),
-        })
-        .then(response => response.json())
-        .then(data => {
-          if (data.success) {
-            alert('게시글이 신고되었습니다.');
-          } else {
-            alert('게시글 신고에 실패했습니다.');
-          }
-        })
-        .catch(error => {
-          console.error('Error:', error);
-          alert('요청에 실패했습니다.');
-        });
-      } else {
-        alert('게시글 ID를 찾을 수 없습니다.');
-      }
+      reportModal.style.display = 'block';
+      reportModalContainer.style.display = 'block';
+
+      isReportButtonClicked = false;
     });
   });
+
+  // 신고하기 버튼 클릭 시 API 요청
+  function handleReportSubmit(event) {
+    event.preventDefault();
+
+    if (isReportButtonClicked) {
+      alert('이미 신고가 제출되었습니다.');
+      return;
+    }
+
+    const selectedReportType = reportTypeSelect.value;
+    const postId = reportModalContainer.getAttribute('data-post-id');
+
+    if (!selectedReportType) {
+      alert('신고 사유를 선택해주세요.');
+      return;
+    }
+
+    isReportButtonClicked = true;
+
+    fetch(`/api/post/report/${postId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        reportType: selectedReportType,
+      }),
+    })
+    .then(response => {
+      if (response.ok) {
+        alert('신고가 완료되었습니다.');
+        reportModal.style.display = 'none';
+        reportModalContainer.style.display = 'none';
+      } else {
+        return response.json().then(errorData => {
+          alert(`신고 실패: ${errorData.message || '알 수 없는 오류 발생'}`);
+        });
+      }
+    })
+    .catch(error => {
+      alert('네트워크 오류가 발생했습니다. 다시 시도해 주세요.');
+    });
+  }
+
+  if (!reportSendButton.hasEventListener) {
+    reportSendButton.addEventListener('click', handleReportSubmit);
+    reportSendButton.hasEventListener = true;
+  }
+
+  closeReportModalButton.addEventListener('click', function () {
+    reportModal.style.display = 'none';
+    reportModalContainer.style.display = 'none';
+  });
+
+  window.addEventListener('click', function (event) {
+    if (event.target === reportModal) {
+      reportModal.style.display = 'none';
+      reportModalContainer.style.display = 'none';
+    }
+  });
 }
+
 
 function openModal(followers) {
   const followerList = document.getElementById("followerList");
@@ -405,7 +643,6 @@ function openModal(followers) {
     });
   }
 
-  // 모달을 표시
   const myModal = new bootstrap.Modal(document.getElementById('followerModal'));
   myModal.show();
 }

--- a/src/main/resources/static/style/common.css
+++ b/src/main/resources/static/style/common.css
@@ -607,6 +607,8 @@ h1 {
   flex-direction: column;
   margin-right: auto;
   gap: 0.7rem;
+  width: 100%;
+  cursor: pointer;
 }
 
 .passed-time {

--- a/src/main/resources/templates/fragments/modals/profile-update-modal.html
+++ b/src/main/resources/templates/fragments/modals/profile-update-modal.html
@@ -1,6 +1,20 @@
-<!-- 프로필 수정 모달 시작-->
 <div class="profile-update-modal" id="profileUpdateModalBackground"
      th:fragment="profile-update-modal">
+  <input
+      type="file"
+      id="profile-image-input"
+      name="profileImage"
+      accept="image/*"
+      style="display: none;"
+  />
+  <div class="modal-overlay" id="modal-overlay"></div>
+  <div id="image-action-modal" class="image-action-modal">
+    <div class="modal-content">
+      <button id="delete-photo-btn" class="action-button">기본 이미지로 변경</button>
+      <button id="upload-photo-btn" class="action-button">컴퓨터에서 업로드</button>
+      <button id="close-modal-btn" class="action-button">취소</button>
+    </div>
+  </div>
   <div
       class="profile-update-modal-container"
       id="profileUpdateModalContainer"
@@ -15,7 +29,7 @@
             alt="close icon"
         />
       </div>
-      <form action="">
+      <form id="profile_form">
         <div class="profile-input-container">
           <div class="name-photo-container">
             <div class="user-name-container">
@@ -25,17 +39,18 @@
               <input
                   class="profile-input"
                   type="text"
-                  name="user-name"
+                  name="name"
                   id="user-name"
                   placeholder="이름 입력"
+                  disabled
                   th:value="${session.name}"
-                  required
               />
             </div>
             <img
+                id="user-photo"
                 class="user-photo"
-                th:src="@{/images/icons/UI-user2.png}"
-                alt=""
+                th:src="${session.profileImage}"
+                alt="프로필 이미지"
             />
           </div>
           <div class="user-nickname-container">
@@ -45,7 +60,7 @@
             <input
                 class="profile-input"
                 type="text"
-                name="user-nickname"
+                name="nickname"
                 id="user-nickname"
                 placeholder="닉네임 입력"
                 th:value="${session.nickname}"
@@ -59,7 +74,7 @@
             <input
                 class="profile-input"
                 type="text"
-                name="user-intruduce"
+                name="introduce"
                 id="user-introduce"
                 placeholder="소개 입력"
                 th:value="${session.introduce}"
@@ -81,7 +96,7 @@
             />
             <span><button type="button" id="toggle-password-sign-in" aria-label="비밀번호 표시/숨기기">표시️</button></span>
           </div>
-          <button class="profile-update-complete-button">완료</button>
+          <button type="button" class="profile-update-complete-button" id="update_profile_button">완료</button>
         </div>
       </form>
     </div>

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" th:href="@{/style/common.css}"/>
   <link rel="stylesheet" th:href="@{/style/profile.css}">
   <link rel="stylesheet" th:href="@{/style/profile-password-view.css}"/>
+  <link rel="stylesheet" th:href="@{/style/fileModal.css}"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link
@@ -79,6 +80,7 @@
       <div th:replace="~{fragments/modals/profile-update-modal :: profile-update-modal}"></div>
       <div th:replace="~{fragments/modals/new-post-modal :: new-post-modal}"></div>
       <div th:replace="~{fragments/modals/manito-confirm-message-modal :: manito-confirm-message-modal}"></div>
+      <div th:replace="~{fragments/modals/report-modal :: report-modal}"></div>
 
       <!--작성 시간, 답글 보이지 않는 가장 기본 게시글 덩어리-->
       <div id="postsContainer" class="posts-container">


### PR DESCRIPTION
## :mag_right: 작업 내용
- 게시글 좋아요 토글로 변경
- 게시물 숨기기 토글로 변경
- 게시물 내용 클릭 시 상세보기 페이지로 이동하도록 변경
- 게시물 신고 연결
- 팔로우한 유저의 게시글과 내 게시글에는 팔로우 버튼이 보이지 않도록 수정
- 유저 프로필 수정부분 연결

## ⚫️이미지 첨부
|내 피드|좋아요 누른 피드|팔로우 한 유저의 피드|
|---|---|---|
|![image](https://github.com/user-attachments/assets/86946894-154f-460b-b93a-2bce5ebc76d4)|![image](https://github.com/user-attachments/assets/8679278f-72a0-41a9-a644-07bc5d31576d)|![image](https://github.com/user-attachments/assets/5e997a3d-7fe2-47bb-a215-7481bc354b8f)|
|게시물 신고|상세 정보로 이동|
|![image](https://github.com/user-attachments/assets/f0b4b316-5f65-46a2-bd37-dd84a797c25d)|![image](https://github.com/user-attachments/assets/5bc2deb2-1601-44f6-a8f9-be48567fed65)|

## :heavy_plus_sign: 이슈 링크
#127 
