### PR TITLE
[ feat ] : 타임라인에서 게시글 상세 페이지 이동, 더보기 버튼 상호작용 등

### DIFF
--- a/src/main/java/com/finalproject/manitoone/domain/MatchProcessStatus.java
+++ b/src/main/java/com/finalproject/manitoone/domain/MatchProcessStatus.java
@@ -25,7 +25,7 @@ public class MatchProcessStatus {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name="id", nullable = false)
+  @Column(name="process_id", nullable = false)
   private Long id;
 
   @Column(name="nickname", nullable = false)

--- a/src/main/java/com/finalproject/manitoone/repository/ManitoMatchesRepository.java
+++ b/src/main/java/com/finalproject/manitoone/repository/ManitoMatchesRepository.java
@@ -29,13 +29,14 @@ public interface ManitoMatchesRepository extends JpaRepository<ManitoMatches, Lo
   // 배정 가능한 포스트 조회
   @Query("SELECT DISTINCT p FROM Post p " +
       "WHERE p.isManito = true " +
+      "AND p.isHidden = false " +  // 사용자가 숨기지 않은 포스트만
+      "AND p.isBlind = false " +   // 관리자가 블라인드 처리하지 않은 포스트만
       "AND p.createdAt > :timeLimit " +
       "AND p.user.userId != :userId " +
       "AND (NOT EXISTS (SELECT 1 FROM ManitoMatches m WHERE m.matchedPostId = p) " +
       "OR EXISTS (SELECT 1 FROM ManitoMatches m " +
       "          WHERE m.matchedPostId = p " +
-      "          AND m.matchedTime = (SELECT MAX(m2.matchedTime) FROM ManitoMatches m2 WHERE m2.matchedPostId = p) "
-      +
+      "          AND m.matchedTime = (SELECT MAX(m2.matchedTime) FROM ManitoMatches m2 WHERE m2.matchedPostId = p) " +
       "          AND m.status IN (com.finalproject.manitoone.constants.MatchStatus.REPORTED, " +
       "                          com.finalproject.manitoone.constants.MatchStatus.EXPIRED, " +
       "                          com.finalproject.manitoone.constants.MatchStatus.PASSED))) " +

--- a/src/main/resources/static/script/manito.js
+++ b/src/main/resources/static/script/manito.js
@@ -786,9 +786,23 @@ const ManitoPage = {
     }
   },
 
+
+  initializePostNavigation() {
+    const postContent = document.querySelector('.todays-manito-post .content-text');
+    if (postContent) {
+      postContent.addEventListener('click', function() {
+        const postId = this.dataset.postId;
+        if (postId) {
+          location.href = `/post/${postId}`;
+        }
+      });
+    }
+  },
+
   init() {
     this.letterBox.init();
     this.modals.init();
+    this.initializePostNavigation();
   }
 };
 
@@ -1331,3 +1345,4 @@ document.addEventListener('DOMContentLoaded', () => {
 document.addEventListener('DOMContentLoaded', () => {
   ManitoPage.init();
 });
+

--- a/src/main/resources/static/script/timeline.js
+++ b/src/main/resources/static/script/timeline.js
@@ -259,19 +259,6 @@ document.addEventListener("DOMContentLoaded", function () {
     event.stopPropagation();
   }
 
-  function addDocumentClickEventListener() {
-    document.addEventListener('click', function(event) {
-      const isClickInsideMenu = event.target.closest('.more-options-menu');
-      const isClickInsideButton = event.target.closest('.tiny-icons[alt="more options"]');
-
-      if (!isClickInsideMenu && !isClickInsideButton) {
-        document.querySelectorAll('.more-options-menu').forEach(menu => {
-          menu.classList.remove('visible');
-          menu.classList.add('hidden');
-        });
-      }
-    });
-  }
 
   function showLoader() {
     const existingLoader = document.querySelector('.timeline-loader');

--- a/src/main/resources/static/script/timeline.js
+++ b/src/main/resources/static/script/timeline.js
@@ -3,10 +3,16 @@ document.addEventListener("DOMContentLoaded", function () {
   const postsContainer = document.querySelector(".timeline-posts");
   let isLoading = false;
   let hasMorePosts = true;
+  const nickname = document.querySelector('meta[name="user-nickname"]').content;
 
   loadPosts();
-
   window.addEventListener('scroll', handleScroll);
+  postsContainer.addEventListener('click', function(event) {
+    const moreOptionsButton = event.target.closest('.tiny-icons[alt="more options"]');
+    if (moreOptionsButton) {
+      handleMoreOptionsClick(event, moreOptionsButton);
+    }
+  });
 
   function handleScroll() {
     if (window.innerHeight + window.scrollY >= document.body.scrollHeight - 100) {
@@ -17,39 +23,82 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  function loadPosts() {
+  async function loadPosts() {
     if (isLoading) return;
 
     isLoading = true;
-    showLoader();
+    if (pageNum === 0) showLoader();
 
-    fetch(`/api/timeline?page=${pageNum}&size=20`)
-    .then(response => response.json())
-    .then(data => {
+    try {
+      const response = await fetch(`/api/timeline?page=${pageNum}&size=20`);
+      const data = await response.json();
+
       if (data.content && data.content.length > 0) {
-        data.content.forEach(post => {
-          const postElement = createPostElement(post);
+        let hasAddedPosts = false;
+
+        for (const post of data.content) {
+          const postElement = await createPostElement(post);
           postsContainer.appendChild(postElement);
-        });
+          hasAddedPosts = true;
+
+          // 첫 번째 포스트가 추가되면 로딩 인디케이터 제거
+          if (hasAddedPosts && pageNum === 0) {
+            hideLoader();
+          }
+        }
+
         hasMorePosts = !data.last;
+        attachEventListeners();
       } else {
         hasMorePosts = false;
         if (pageNum === 0) {
           showEmptyState();
         }
       }
-    })
-    .catch(error => {
+    } catch (error) {
       console.error('Error loading posts:', error);
       showError();
-    })
-    .finally(() => {
+    } finally {
       isLoading = false;
       hideLoader();
-    });
+    }
   }
 
-  function createPostElement(post) {
+
+  function attachEventListeners() {
+    // 기존의 이벤트 리스너들을 제거
+    removeExistingEventListeners();
+
+    addFriendButtonsEventListener();
+    addHidePostEventListener();
+    addReportPostEventListener();
+    addPostLikeEventListener();
+    addPostDeleteEventHandler();
+    postContentEventListener();
+  }
+
+  function removeExistingEventListeners() {
+    const elements = {
+      'img[alt="add friend"]': 'click',
+      '.hide-post': 'click',
+      '.report-post': 'click',
+      'img[alt="I like this"]': 'click',
+      '.delete-post': 'click',
+      '.content-text': 'click'
+    };
+
+    for (const [selector, event] of Object.entries(elements)) {
+      const elements = document.querySelectorAll(selector);
+      elements.forEach(element => {
+        element.replaceWith(element.cloneNode(true));
+      });
+    }
+  }
+
+  async function createPostElement(post) {
+    const isFollowed = await getIsFollowed(post.nickName);
+    const isMyPost = post.nickName === nickname;
+
     const postElement = document.createElement("div");
     postElement.classList.add("post-container");
 
@@ -58,45 +107,41 @@ document.addEventListener("DOMContentLoaded", function () {
         timeForToday(post.createdAt);
 
     postElement.innerHTML = `
-      <img 
-        class="user-photo" 
-        src="${post.profileImage || '/images/icons/UI-user2.png'}" 
-        alt="user icon"
-      />
+      <a href="/profile/${post.nickName}">
+        <img class="user-photo" src="${post.profileImage || '/images/icons/UI-user2.png'}" alt="user icon" />
+      </a>
       <div class="post-content">
         <div class="user-info">
           <a href="/profile/${post.nickName}" class="user-name">${post.nickName}</a>
-          <span class="passed-time">${timeText}</span>
+          <span class="passed-time" data-created-at="${post.createdAt}" data-updated-at="${post.updatedAt}">${timeText}</span>
         </div>
-        <p class="content-text">${post.content}</p>
-        ${createImagesHTML(post.postImages)}
+        <p class="content-text" data-post-id="${post.postId}">${post.content}</p>
+        ${post.postImages ? createImagesHTML(post.postImages) : ''}
         <div class="reaction-icons">
-          <img 
-            class="tiny-icons" 
-            src="/images/icons/icon-clover2.png" 
-            alt="I like this"
-          />
+          ${isMyPost
+        ? `<img class="tiny-icons" src="/images/icons/icon-clover2.png" alt="my post"/>`
+        : `<img class="tiny-icons" src="/images/icons/icon-clover2.png" alt="I like this" data-post-id="${post.postId}"/>`}
           <span class="like-count">${post.likeCount}</span>
-          <img 
-            class="tiny-icons" 
-            src="/images/icons/icon-comment2.png" 
-            alt="add reply"
-          />
+          <img class="tiny-icons" src="/images/icons/icon-comment2.png" alt="add reply" />
           <span class="reply-count">${post.replies.length}</span>
         </div>
       </div>
       <div class="option-icons">
-        <img 
-          class="tiny-icons" 
-          src="/images/icons/UI-more2.png" 
-          alt="more options"
-        />
-        <img 
-          class="tiny-icons" 
-          src="/images/icons/icon-add-friend.png" 
-          alt="add friend" 
-          data-target-id="${post.nickName}"
-        />
+        <img class="tiny-icons" src="/images/icons/UI-more2.png" alt="more options" />
+        ${(!isMyPost && !isFollowed)
+        ? `<img class="tiny-icons" src="/images/icons/icon-add-friend.png" alt="add friend" data-target-id="${post.nickName}"/>`
+        : ''} 
+        <div class="more-options-menu hidden">
+          <ul>
+            ${isMyPost
+        ? `
+                <li><a href="#" class="hide-post" data-post-id="${post.postId}">숨기기</a></li>
+                <hr>
+                <li><a href="#" class="delete-post" data-post-id="${post.postId}">삭제하기</a></li>
+              `
+        : `<li><a href="#" class="report-post" data-post-id="${post.postId}">신고하기</a></li>`}
+          </ul>
+        </div>
       </div>
     `;
 
@@ -105,22 +150,31 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function createImagesHTML(images) {
     if (!images || images.length === 0) return '';
+    return `<img class="post-image" src="/images/upload/${images[0].fileName}" alt="post image"/>`;
+  }
 
-    return `
-      <img 
-        class="post-image" 
-        src="/images/upload/${images[0].fileName}" 
-        alt="post image"
-      />
-    `;
+  async function getIsFollowed(nickName) {
+    try {
+      const response = await fetch(`/api/follow/followed/${nickName}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      const body = await response.text();
+      return body === 'true';
+    } catch (error) {
+      console.error("팔로우 상태를 가져오는데 실패했습니다:", error);
+      return false;
+    }
   }
 
   function timeForToday(value) {
     const today = new Date();
     const timeValue = new Date(value);
     const betweenTime = Math.floor(
-        (today.getTime() - timeValue.getTime()) / 1000 / 60
-    );
+        (today.getTime() - timeValue.getTime()) / 1000 / 60);
 
     if (betweenTime < 1) return '방금전';
     if (betweenTime < 60) return `${betweenTime}분전`;
@@ -135,31 +189,114 @@ document.addEventListener("DOMContentLoaded", function () {
     return `${Math.floor(betweenTimeDay / 365)}년전`;
   }
 
+  function addFriendButtonsEventListener() {
+    const addFriendButtons = document.querySelectorAll('img[alt="add friend"]');
+    addFriendButtons.forEach(button =>
+        button.addEventListener("click", handleAddFriendClick));
+  }
+
+  function handleAddFriendClick() {
+    const targetId = this.dataset.targetId;
+    fetch(`/api/follow/${targetId}`)
+    .then(response => {
+      if (response.status === 201 || response.status === 200) {
+        // 팔로우 버튼을 숨기고 성공 메시지 표시
+        this.style.display = 'none';
+        alert('팔로우가 완료되었습니다.');
+      } else {
+        alert("오류가 발생했습니다.");
+      }
+    })
+    .catch(error => console.error("API 호출 중 오류 발생:", error));
+  }
+
+  function handleFollowResponse(response, button) {
+    if (response.status === 201 || response.status === 200) {
+      location.reload();
+      button.alt = response.status === 201 ? "remove friend" : "add friend";
+    } else {
+      alert("오류가 발생했습니다.");
+    }
+  }
+
+  function postContentEventListener() {
+    const postContents = document.querySelectorAll('.content-text');
+    postContents.forEach(content =>
+        content.addEventListener("click", handlePostContentClick));
+  }
+
+  function handlePostContentClick() {
+    const postId = this.dataset.postId;
+    location.href = "/post/" + postId;
+  }
+
+  function handleMoreOptionsClick(event, moreOptionsButton) {
+    const optionsMenu = moreOptionsButton.closest('.option-icons').querySelector('.more-options-menu');
+    if (!optionsMenu) return;
+
+    const offsetX = event.clientX;
+    const offsetY = event.clientY;
+    const scrollY = window.scrollY;
+
+    optionsMenu.style.top = `${offsetY + scrollY}px`;
+    optionsMenu.style.left = `${offsetX}px`;
+
+    const isMenuVisible = optionsMenu.classList.contains('visible');
+
+    document.querySelectorAll('.more-options-menu').forEach(menu => {
+      menu.classList.remove('visible');
+      menu.classList.add('hidden');
+    });
+
+    if (isMenuVisible) {
+      optionsMenu.classList.remove('visible');
+      optionsMenu.classList.add('hidden');
+    } else {
+      optionsMenu.classList.remove('hidden');
+      optionsMenu.classList.add('visible');
+    }
+
+    event.stopPropagation();
+  }
+
+  function addDocumentClickEventListener() {
+    document.addEventListener('click', function(event) {
+      const isClickInsideMenu = event.target.closest('.more-options-menu');
+      const isClickInsideButton = event.target.closest('.tiny-icons[alt="more options"]');
+
+      if (!isClickInsideMenu && !isClickInsideButton) {
+        document.querySelectorAll('.more-options-menu').forEach(menu => {
+          menu.classList.remove('visible');
+          menu.classList.add('hidden');
+        });
+      }
+    });
+  }
+
   function showLoader() {
-    const loader = document.createElement('div');
-    loader.className = 'timeline-loader';
-    loader.innerHTML = '<div class="loader-content">로딩 중...</div>';
-    postsContainer.appendChild(loader);
+    const existingLoader = document.querySelector('.timeline-loader');
+    if (!existingLoader) {
+      const loader = document.createElement('div');
+      loader.className = 'timeline-loader';
+      loader.innerHTML = '<div class="loader-content">로딩 중...</div>';
+      postsContainer.appendChild(loader);
+    }
   }
 
   function hideLoader() {
     const loader = document.querySelector('.timeline-loader');
-    if (loader) loader.remove();
+    if (loader) {
+      loader.remove();
+    }
   }
 
   function showEmptyState() {
     postsContainer.innerHTML = `
       <div class="empty-timeline">
         <div class="empty-timeline-content">
-          <img 
-            src="/images/icons/UI-clover2.png" 
-            alt="empty state icon" 
-            class="empty-timeline-icon"
-          />
+          <img src="/images/icons/UI-clover2.png" alt="empty state icon" class="empty-timeline-icon"/>
           <h2 class="empty-timeline-title">아직 표시할 게시물이 없습니다</h2>
-          <p class="empty-timeline-description">
-            다른 사용자를 팔로우하고 새로운 이야기를 발견해보세요!
-          </p>
+          <p class="empty-timeline-description">다른 사용자를 팔로우하고 새로운 이야기를 발견해보세요!</p>
         </div>
       </div>
     `;
@@ -173,6 +310,176 @@ document.addEventListener("DOMContentLoaded", function () {
           <button onclick="location.reload()">다시 시도</button>
         </div>
       `;
+    }
+  }
+
+  function addHidePostEventListener() {
+    const hidePostButtons = document.querySelectorAll('.hide-post');
+    hidePostButtons.forEach(button => {
+      button.addEventListener('click', function () {
+        const postId = this.dataset.postId;
+
+        if (postId) {
+          fetch('/api/post/hidden/' + postId, {
+            method: 'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({postId: postId}),
+          })
+          .then(response => {
+            if (response.ok) {
+              alert('게시글 숨기기가 완료되었습니다.');
+              // 숨기기 성공 시 해당 게시글 요소 제거
+              const postContainer = button.closest('.post-container');
+              postContainer.remove();
+            } else {
+              alert('게시글 숨기기에 실패했습니다.');
+            }
+          })
+          .catch(error => {
+            console.error('Error:', error);
+            alert(error.message || '요청에 실패했습니다.');
+          });
+        } else {
+          alert('게시글 ID를 찾을 수 없습니다.');
+        }
+      });
+    });
+  }
+
+  function addPostLikeEventListener() {
+    const likePostButtons = document.querySelectorAll('img[alt="I like this"]');
+    likePostButtons.forEach(button => {
+      button.addEventListener('click', async function () {
+        const postId = this.dataset.postId;
+        if (!postId) return;
+
+        try {
+          const likeResponse = await fetch('/api/post/like/' + postId, {
+            method: 'POST'
+          });
+
+          if (likeResponse.ok) {
+            const numberResponse = await fetch('/api/post/like/number/' + postId);
+            const countText = await numberResponse.text();
+            const currentLikes = parseInt(countText, 10);
+
+            const likeCountElement = button.closest('div').querySelector('.like-count');
+            if (likeCountElement) {
+              likeCountElement.textContent = currentLikes;
+              button.classList.toggle('liked');
+            }
+          }
+        } catch (error) {
+          console.error('Error handling like:', error);
+        }
+      });
+    });
+  }
+
+  function addPostDeleteEventHandler() {
+    const deletePostButtons = document.querySelectorAll('.delete-post');
+    deletePostButtons.forEach(button => {
+      button.addEventListener('click', function () {
+        if (!confirm('정말로 이 게시글을 삭제하시겠습니까?')) {
+          return;
+        }
+        const postId = this.dataset.postId;
+        if (postId) {
+          fetch('/api/post/' + postId, {
+            method: 'DELETE'
+          })
+          .then(response => {
+            if (response.status === 200) {
+              alert('게시글이 삭제되었습니다.');
+              const postContainer = button.closest('.post-container');
+              postContainer.remove();
+            }
+          });
+        }
+      });
+    });
+  }
+
+  function addReportPostEventListener() {
+    const reportPostButtons = document.querySelectorAll('.report-post');
+    const reportModal = document.getElementById('reportModal');
+    const reportModalContainer = document.getElementById('reportModalContainer');
+    const closeReportModalButton = document.getElementById('closeReportModalBtn');
+    const reportSendButton = document.getElementById('reportSendBtn');
+    const reportTypeSelect = document.getElementById('report-type-select');
+
+    let isReportButtonClicked = false;
+
+    reportPostButtons.forEach(button => {
+      button.addEventListener('click', function () {
+        const postId = button.getAttribute('data-post-id');
+        reportModalContainer.setAttribute('data-post-id', postId);
+        reportModal.style.display = 'block';
+        reportModalContainer.style.display = 'block';
+        isReportButtonClicked = false;
+      });
+    });
+
+    if (reportSendButton && !reportSendButton.hasEventListener) {
+      reportSendButton.addEventListener('click', handleReportSubmit);
+      reportSendButton.hasEventListener = true;
+    }
+
+    if (closeReportModalButton) {
+      closeReportModalButton.addEventListener('click', function () {
+        reportModal.style.display = 'none';
+        reportModalContainer.style.display = 'none';
+      });
+    }
+
+    window.addEventListener('click', function (event) {
+      if (event.target === reportModal) {
+        reportModal.style.display = 'none';
+        reportModalContainer.style.display = 'none';
+      }
+    });
+
+    function handleReportSubmit(event) {
+      event.preventDefault();
+
+      if (isReportButtonClicked) {
+        alert('이미 신고가 제출되었습니다.');
+        return;
+      }
+
+      const selectedReportType = reportTypeSelect.value;
+      const postId = reportModalContainer.getAttribute('data-post-id');
+
+      if (!selectedReportType) {
+        alert('신고 사유를 선택해주세요.');
+        return;
+      }
+
+      isReportButtonClicked = true;
+
+      // URL에 reportType을 쿼리 파라미터로 추가
+      fetch(`/api/post/report/${postId}?reportType=${selectedReportType}`, {
+        method: 'POST',  // PUT에서 POST로 변경
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      })
+      .then(response => {
+        if (response.ok) {
+          alert('신고가 완료되었습니다.');
+          reportModal.style.display = 'none';
+          reportModalContainer.style.display = 'none';
+        } else {
+          return response.json().then(errorData => {
+            alert(`신고 실패: ${errorData.message || '알 수 없는 오류 발생'}`);
+          });
+        }
+      })
+      .catch(error => {
+        alert('네트워크 오류가 발생했습니다. 다시 시도해 주세요.');
+      });
     }
   }
 });

--- a/src/main/resources/static/style/timeline.css
+++ b/src/main/resources/static/style/timeline.css
@@ -1,0 +1,17 @@
+.more-options-menu {
+  display: none;
+  position: absolute;
+  z-index: 1000;
+  background-color: white;
+  padding: 10px;
+  border-radius: 5px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.hidden {
+  display: none;
+}
+
+.visible {
+  display: block;
+}

--- a/src/main/resources/templates/fragments/content/manito.html
+++ b/src/main/resources/templates/fragments/content/manito.html
@@ -33,13 +33,11 @@
           />
           <div class="post-content">
             <div class="user-info">
-              <span class="user-name" th:text="${todaysPost.nickName}">beer_lover</span>
+              <a th:href="@{'/profile/' + ${todaysPost.nickName}}" class="user-name" th:text="${todaysPost.nickName}">beer_lover</a>
               <span class="passed-time" th:text="${todaysPost.formattedTime}">3분</span>
             </div>
-            <p class="content-text" th:text="${todaysPost.content}">
-              오늘 일 완전 힘들었다... 스트레스 받아서 귀가하는 길에 지친
-              심신을 달래줄 맥주 한 캔 샀음~ <br/>
-              아쉽지만 치킨은 없다ㅋㅋ 이번달 돈 아껴야 해~~
+            <p class="content-text" th:text="${todaysPost.content}" th:data-post-id="${todaysPost.postId}" style="cursor: pointer">
+            </p>
             </p>
             <img
                 class="post-image"
@@ -65,18 +63,6 @@
               <span class="reply-count"
                     th:text="${todaysPost.replies != null ? todaysPost.replies.size() : 0}">3</span>
             </div>
-          </div>
-          <div class="option-icons">
-            <img
-                class="tiny-icons"
-                th:src="@{/images/icons/UI-more2.png}"
-                alt="more options"
-            />
-            <img
-                class="tiny-icons"
-                th:src="@{/images/icons/icon-add-friend.png}"
-                alt="add friend"
-            />
           </div>
         </div>
       </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="@{/style/reset.css}" />
     <link rel="stylesheet" th:href="@{/style/common.css}" />
     <link rel="stylesheet" th:href="@{/style/tooltip.css}" />
+    <link rel="stylesheet" th:href="@{/style/timeline.css}">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -31,6 +32,7 @@
         <div
           th:replace="~{fragments/modals/new-post-modal :: new-post-modal}"
         ></div>
+        <div th:replace="~{fragments/modals/report-modal :: report-modal}"></div>
       </section>
       <article
         th:replace="~{fragments/common/right-section :: right-section}"


### PR DESCRIPTION
## :mag_right: 작업 내용

- 타임라인에서 게시글 내용을 누르면 상세 페이지로 이동합니다.
- 타임라인에서 유저 이름을 누르면 유저 페이지로 이동합니다.
- 타임라인에서 내가 팔로우하지 않은 유저만 팔로우 버튼이 보입니다.
- 타임라인에서 내 게시물과 타인의 게시물의 더보기 버튼이 활성화됩니다 : 내 게시물 -> 숨기기, 삭제 / 타인의 게시물 -> 신고하기
- 타임라인에서 무한스크롤이 되지 않던 문제 수정
- 마니또 페이지에서 마니또 게시글의 유저명이나 내용을 누르면 해당하는 페이지로 이


## ⚫️이미지 첨부
<br/>


## :heavy_plus_sign: 이슈 링크

- [#125](이슈 주소)
