### PR TITLE
fix: 좋아요 취소 후 다시 좋아요가 안되는 오류 수정

### DIFF
--- a/src/main/java/com/finalproject/manitoone/service/PostService.java
+++ b/src/main/java/com/finalproject/manitoone/service/PostService.java
@@ -337,11 +337,6 @@ public class PostService {
             IllegalActionMessages.CANNOT_FIND_POST_WITH_GIVEN_ID.getMessage()
         ));
     
-    userPostLikeRepository.save(UserPostLike.builder()
-        .post(post)
-        .user(user)
-        .build());
-    
     Optional<UserPostLike> existingLike = userPostLikeRepository.findByUser_UserIdAndPost_PostId(user.getUserId(), post.getPostId());
 
     if (existingLike.isPresent()) {


### PR DESCRIPTION
## :mag_right: 작업 내용
- 게시글 타임라인에서 좋아요 취소 후 좋아요가 안되는 문제 해결

## ⚫️이미지 첨부

## :heavy_plus_sign: 이슈 링크

