### PR TITLE
[ feat ] 타임라인에서 사진 표시

### DIFF
--- a/src/main/java/com/finalproject/manitoone/dto/manito/ManitoLetterResponseDto.java
+++ b/src/main/java/com/finalproject/manitoone/dto/manito/ManitoLetterResponseDto.java
@@ -20,4 +20,5 @@ public class ManitoLetterResponseDto {
   private boolean isOwner;
   private LocalDateTime createdAt;
   private String formattedCreatedAt;
+  private Long postId;
 }

--- a/src/main/java/com/finalproject/manitoone/service/ManitoService.java
+++ b/src/main/java/com/finalproject/manitoone/service/ManitoService.java
@@ -130,6 +130,7 @@ public class ManitoService {
         .isOwner(letter.isOwnedBy(currentUser))
         .createdAt(letter.getCreatedAt())
         .formattedCreatedAt(TimeFormatter.formatDateTime(letter.getCreatedAt()))
+        .postId(letter.getManitoMatches().getMatchedPostId().getPostId())
         .build();
   }
 

--- a/src/main/resources/static/script/common.js
+++ b/src/main/resources/static/script/common.js
@@ -458,6 +458,36 @@ const CommonUtils = {
     container.appendChild(loadingMessage);
   },
 
+  initializePreviousButton() {
+    const previousButton = document.querySelector('.previous-button');
+    if (previousButton) {
+      previousButton.addEventListener('click', () => {
+        // 브라우저 히스토리가 있는 경우
+        if (window.history.length > 1) {
+          window.history.back();
+        } else {
+          // 히스토리가 없는 경우 (직접 URL로 접근한 경우) 기본 페이지로 이동
+          window.location.href = '/';
+        }
+      });
+    }
+  },
+
+  initializePageModals() {
+    try {
+      if (document.getElementById("newPostFormModalContainer")) {
+        new PostFormModal();
+      }
+      if (document.getElementById("profileUpdateModalContainer")) {
+        new ProfileUpdateModal();
+      }
+      // 이전 버튼 초기화 추가
+      this.initializePreviousButton();
+    } catch (error) {
+      console.error('모달 초기화 중 오류 발생:', error);
+    }
+  },
+
   initializeLetterEventListeners(elements) {
 
     elements.receivedList?.addEventListener('click', (e) => {

--- a/src/main/resources/static/script/manito.js
+++ b/src/main/resources/static/script/manito.js
@@ -803,6 +803,16 @@ const ManitoPage = {
     this.letterBox.init();
     this.modals.init();
     this.initializePostNavigation();
+    this.initializeLetterContentClick();
+  },
+
+  initializeLetterContentClick() {
+    document.addEventListener('click', (e) => {
+      const content = e.target.closest('.manito-content-text');
+      if (content && content.dataset.postId) {
+        window.location.href = `/post/${content.dataset.postId}`;
+      }
+    });
   }
 };
 
@@ -847,8 +857,9 @@ class ManitoLetterRenderer {
             <span class="manito-user-name">익명의 마니또</span>
             <span class="passed-time">${letter.timeDiff}</span>
           </div>
-          <p class="manito-content-text">${letter.letterContent?.replace(/\n/g,
-        '<br>') || ''}</p>
+          <p class="manito-content-text ${letter.postId ? 'clickable-content' : ''}" 
+   ${letter.postId ? `data-post-id="${letter.postId}"` : ''}
+   style="${letter.postId ? 'cursor: pointer;' : ''}">${letter.letterContent?.replace(/\n/g, '<br>') || ''}</p>
           <div class="manito-recommend-music">
             <div class="recommend-music">
               <img class="tiny-icons-linkless" src="/images/icons/icon-music.png" alt="music icon" />

--- a/src/main/resources/static/script/timeline.js
+++ b/src/main/resources/static/script/timeline.js
@@ -120,7 +120,13 @@ document.addEventListener("DOMContentLoaded", function () {
           <span class="passed-time" data-created-at="${post.createdAt}" data-updated-at="${post.updatedAt}">${timeText}</span>
         </div>
         <p class="content-text" data-post-id="${post.postId}">${post.content}</p>
-        ${post.postImages ? createImagesHTML(post.postImages) : ''}
+        ${post.postImages && post.postImages.length > 0 ? `
+          <div class="image-container">
+            ${post.postImages.map(image => `
+              <img class="post-image" src="${image.fileName}" alt="post image"/>
+            `).join('')}
+          </div>
+        ` : ''}
         <div class="reaction-icons">
           ${isMyPost
         ? `<img class="tiny-icons" src="/images/icons/icon-clover2.png" alt="my post"/>`
@@ -156,7 +162,13 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!images || images.length === 0) {
       return '';
     }
-    return `<img class="post-image" src="/images/upload/${images[0].fileName}" alt="post image"/>`;
+    return `
+    <div class="image-container">
+      ${images.map(image => `
+        <img class="post-image" src="/images/upload/${image.fileName}" alt="post image"/>
+      `).join('')}
+    </div>
+  `;
   }
 
   async function getIsFollowed(nickName) {

--- a/src/main/resources/static/style/common.css
+++ b/src/main/resources/static/style/common.css
@@ -14,6 +14,8 @@ body {
 
 .previous-button {
   margin-bottom: 1rem;
+  width: fit-content;
+  cursor: pointer;
 }
 
 .previous-icon {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="@{/style/reset.css}" />
     <link rel="stylesheet" th:href="@{/style/common.css}" />
     <link rel="stylesheet" th:href="@{/style/timeline.css}">
+    <link rel="stylesheet" th:href="@{/style/post.css}">
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/main/resources/templates/pages/post/postDetail.html
+++ b/src/main/resources/templates/pages/post/postDetail.html
@@ -1,602 +1,606 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="user-nickname" th:content="${post.user.nickname}" />
-    <link rel="stylesheet" th:href="@{/style/reset.css}" />
-    <link rel="stylesheet" th:href="@{/style/common.css}" />
-    <link rel="stylesheet" th:href="@{/style/post.css}" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="user-nickname" th:content="${post.user.nickname}"/>
+  <link rel="stylesheet" th:href="@{/style/reset.css}"/>
+  <link rel="stylesheet" th:href="@{/style/common.css}"/>
+  <link rel="stylesheet" th:href="@{/style/post.css}"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link
       rel="icon"
       type="image/x-icon"
       th:href="@{/images/favicon/favicon.ico}"
-    />
-    <title>ManiToOne</title>
-  </head>
-  <body>
-    <header th:replace="~{fragments/common/header :: header}"></header>
-    <main class="main-container">
-      <section class="middle-section" id="middleSection">
-        <section class="timeline-section">
-          <div class="timeline">
-            <!-- 게시글 -->
-            <div class="post-container">
+  />
+  <title>ManiToOne</title>
+</head>
+<body>
+<header th:replace="~{fragments/common/header :: header}"></header>
+<main class="main-container">
+  <section class="middle-section" id="middleSection">
+    <div class="previous-button">
+      <img class="previous-icon" th:src="@{/images/icons/icon-previous.png}" alt="previous icon">
+    </div>
+    <section class="timeline-section">
+
+      <div class="timeline">
+        <!-- 게시글 -->
+        <div class="post-container">
+          <img
+              class="user-photo"
+              th:src="@{${post.user.profileImage}}"
+              alt="user icon"
+          />
+          <div class="post-content">
+            <div class="user-info">
+                  <span
+                      class="user-name"
+                      th:text="${post.user.nickname}"
+                  ></span>
+              <span
+                  class="passed-time"
+                  th:text="${post.updatedAt != null ? #strings.concat(#temporals.format(post.updatedAt, 'mm'), '분') : #strings.concat(#temporals.format(post.createdAt, 'mm'), '분')}"
+              ></span>
+            </div>
+            <p class="content-text" th:text="${post.content}"></p>
+            <div class="image-container" th:if="${postImages != null}">
               <img
-                class="user-photo"
-                th:src="@{${post.user.profileImage}}"
-                alt="user icon"
+                  th:each="image : ${postImages}"
+                  th:src="@{${image.fileName}}"
+                  alt="uploaded-image"
               />
-              <div class="post-content">
-                <div class="user-info">
-                  <span
-                    class="user-name"
-                    th:text="${post.user.nickname}"
-                  ></span>
-                  <span
-                    class="passed-time"
-                    th:text="${post.updatedAt != null ? #strings.concat(#temporals.format(post.updatedAt, 'mm'), '분') : #strings.concat(#temporals.format(post.createdAt, 'mm'), '분')}"
-                  ></span>
-                </div>
-                <p class="content-text" th:text="${post.content}"></p>
-                <div class="image-container" th:if="${postImages != null}">
-                  <img
-                    th:each="image : ${postImages}"
-                    th:src="@{${image.fileName}}"
-                    alt="uploaded-image"
-                  />
-                </div>
-                <p
-                  class="post-time"
-                  th:text="${post.updatedAt != null ? #temporals.format(post.updatedAt, 'yyyy년 MM월 dd일 a hh시 mm분') : #temporals.format(post.createdAt, 'yyyy년 MM월 dd일 a hh시 mm분')}"
-                ></p>
-                <div class="reaction-icons">
-                  <img
-                    class="tiny-icons"
-                    th:src="@{/images/icons/icon-clover2.png}"
-                    alt="I like this"
-                    th:onclick="'likePost(' + ${post.postId} + ')'"
-                  />
-                  <span
-                    class="like-count"
-                    id="post-like-count"
-                    th:text="${post.likesNumber}"
-                  ></span>
-                  <img
-                    class="tiny-icons"
-                    th:src="@{/images/icons/icon-comment2.png}"
-                    alt="add reply"
-                  />
-                  <span class="reply-count" th:text="${postRepliesNum}"></span>
-                </div>
-              </div>
-              <div class="option-icons">
-                <img
-                  class="tiny-icons"
-                  th:src="@{/images/icons/UI-more2.png}"
-                  alt="more options"
-                  th:onclick="'openPostOptionsModal()'"
-                />
-                <img
-                  class="tiny-icons"
-                  th:if="${currentUser != post.user && !#lists.contains(followings, post.user)}"
-                  th:src="@{/images/icons/icon-add-friend.png}"
-                  alt="add friend"
-                />
-              </div>
-
-              <!-- 게시글 수정 모달 -->
-              <div class="new-post-form-modal" id="updatePostFormModal">
-                <div
-                  class="new-post-form-modal-container"
-                  id="updatePostFormModalContainer"
-                >
-                  <div class="new-post-title">
-                    <p>게시물 수정</p>
-                    <img
-                      class="tiny-icons"
-                      id="closePostFormModalBtn"
-                      th:src="@{/images/icons/icon-cancel.png}"
-                      alt="close icon"
-                      th:onclick="'closeUpdatePostModal()'"
-                    />
-                  </div>
-
-                  <div class="new-post-content-container">
-                    <div class="new-post-content">
-                      <img
-                        class="user-photo"
-                        th:src="@{${post.user.profileImage}}"
-                        alt="user icon"
-                      />
-                      <div class="new-post-text-container">
-                        <textarea
-                          name="content"
-                          id="new-post-content"
-                          class="new-post-text"
-                          th:text="${post.content}"
-                        ></textarea>
-                        <p class="letter-count" id="count500">500/500</p>
-                      </div>
-                    </div>
-
-                    <div class="manito-response-toggle">
-                      <img
-                        class="tiny-icons"
-                        th:src="@{/images/icons/icon-check-empty.png}"
-                        alt="check icon"
-                        data-checked-src="@{/images/icons/icon-check.png}"
-                        data-unchecked-src="@{/images/icons/icon-check-empty.png}"
-                      />
-                      <p>이 게시물에 대해 마니또의 답변을 받습니다.</p>
-                    </div>
-
-                    <div
-                      class="ai-response-toggle"
-                      onclick="toggleAI(this)"
-                      style="opacity: 0.3"
-                    >
-                      <img
-                        class="tiny-icons"
-                        th:src="@{/images/icons/icon-check-empty.png}"
-                        alt="check icon"
-                        data-checked-src="@{/images/icons/icon-check.png}"
-                        data-unchecked-src="@{/images/icons/icon-check-empty.png}"
-                      />
-                      <p>이 게시물에 대해 AI의 피드백을 받습니다.</p>
-                    </div>
-                  </div>
-
-                  <div class="post-button-container">
-                    <input
-                      type="file"
-                      id="image-upload-btn"
-                      name="images"
-                      accept="image/jpeg, image/png"
-                      multiple
-                      onchange="countImages(this)"
-                      style="display: none"
-                    />
-                    <img
-                      class="tiny-icons"
-                      th:src="@{/images/icons/icon-image2.png}"
-                      alt="add image icon"
-                      onclick="document.getElementById('image-upload-btn').click()"
-                    />
-                    <button
-                      class="post-button"
-                      type="submit"
-                      th:onclick="'onUpdatePostSubmit(' + ${post.postId} + ')'"
-                    >
-                      수정하기
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <!-- 게시글 신고 모달 -->
-              <div class="report-modal" id="postReportModal">
-                <form
-                  class="report-modal-container"
-                  id="postReportModalContainer"
-                  th:action="@{/api/post/report/{postId}(postId=${post.postId})}"
-                  method="post"
-                  th:onsubmit="'onPostReportSubmit(event)'"
-                >
-                  <div class="report-title">
-                    <p>신고하기</p>
-                    <img
-                      class="tiny-icons"
-                      id="closePostReportModalBtn"
-                      th:src="@{/images/icons/icon-cancel.png}"
-                      alt="close icon"
-                      th:onclick="'closePostReportModal()'"
-                    />
-                  </div>
-                  <div class="report-container">
-                    <label for="post-report-type-select"
-                      >신고 사유를 선택해주세요</label
-                    >
-                    <select
-                      name="reportType"
-                      id="post-report-type-select"
-                      class="report-type-select"
-                    >
-                      <option value="">신고 사유 선택</option>
-                      <option value="DISLIKE">마음에 들지 않습니다</option>
-                      <option value="HARASSMENT">
-                        따돌림 또는 원치 않은 연락
-                      </option>
-                      <option value="SELF_HARM">자살, 자해 및 섭식 장애</option>
-                      <option value="ABUSE">폭력, 혐오 또는 학대</option>
-                      <option value="RESTRICTED_ITEMS">
-                        제한된 품목을 판매하거나 홍보함
-                      </option>
-                      <option value="ADULT_CONTENT">
-                        나체 이미지 또는 성적 행위
-                      </option>
-                      <option value="SCAM">스캠, 사기 또는 스팸</option>
-                      <option value="MISINFO">거짓 정보</option>
-                    </select>
-                  </div>
-                  <div class="report-send-button-container">
-                    <button
-                      class="report-send-button"
-                      id="postReportSendBtn"
-                      type="submit"
-                    >
-                      전송하기
-                    </button>
-                  </div>
-                </form>
-              </div>
             </div>
-
-            <div id="reply-divider" th:onclick="'openNewReplyModal()'">
-              <p id="reply-divider-text">답글</p>
+            <p
+                class="post-time"
+                th:text="${post.updatedAt != null ? #temporals.format(post.updatedAt, 'yyyy년 MM월 dd일 a hh시 mm분') : #temporals.format(post.createdAt, 'yyyy년 MM월 dd일 a hh시 mm분')}"
+            ></p>
+            <div class="reaction-icons">
+              <img
+                  class="tiny-icons"
+                  th:src="@{/images/icons/icon-clover2.png}"
+                  alt="I like this"
+                  th:onclick="'likePost(' + ${post.postId} + ')'"
+              />
+              <span
+                  class="like-count"
+                  id="post-like-count"
+                  th:text="${post.likesNumber}"
+              ></span>
+              <img
+                  class="tiny-icons"
+                  th:src="@{/images/icons/icon-comment2.png}"
+                  alt="add reply"
+              />
+              <span class="reply-count" th:text="${postRepliesNum}"></span>
             </div>
+          </div>
+          <div class="option-icons">
+            <img
+                class="tiny-icons"
+                th:src="@{/images/icons/UI-more2.png}"
+                alt="more options"
+                th:onclick="'openPostOptionsModal()'"
+            />
+            <img
+                class="tiny-icons"
+                th:if="${currentUser != post.user && !#lists.contains(followings, post.user)}"
+                th:src="@{/images/icons/icon-add-friend.png}"
+                alt="add friend"
+            />
+          </div>
 
-            <!-- 답글 작성 모달 -->
-            <div class="new-post-form-modal" id="newReplyFormModal">
-              <div
+          <!-- 게시글 수정 모달 -->
+          <div class="new-post-form-modal" id="updatePostFormModal">
+            <div
                 class="new-post-form-modal-container"
-                id="newReplyFormModalContainer"
-              >
-                <div class="new-post-title">
-                  <p>답글 작성</p>
-                  <img
+                id="updatePostFormModalContainer"
+            >
+              <div class="new-post-title">
+                <p>게시물 수정</p>
+                <img
                     class="tiny-icons"
-                    id="closeNewReplyFormModalBtn"
+                    id="closePostFormModalBtn"
                     th:src="@{/images/icons/icon-cancel.png}"
                     alt="close icon"
-                    th:onclick="'closeNewReplyModal()'"
-                  />
-                </div>
+                    th:onclick="'closeUpdatePostModal()'"
+                />
+              </div>
 
-                <div class="new-post-content-container">
-                  <div class="new-post-content">
-                    <img
-                      class="user-photo"
-                      th:src="@{${currentUser.profileImage}}"
-                      alt="user icon"
-                    />
-                    <div class="new-post-text-container">
-                      <textarea
-                        name="content"
-                        id="new-reply-content"
-                        class="new-post-text"
-                        placeholder="나누고 싶은 글을 작성해주세요"
-                      ></textarea>
-                      <p class="letter-count" id="countTo500">500/500</p>
-                    </div>
-                  </div>
-
-                  <div class="manito-response-toggle">
-                    <img
-                      class="tiny-icons"
-                      th:src="@{/images/icons/icon-check-empty.png}"
-                      alt="check icon"
-                      data-checked-src="@{/images/icons/icon-check.png}"
-                      data-unchecked-src="@{/images/icons/icon-check-empty.png}"
-                    />
-                    <p>이 게시물에 대해 마니또의 답변을 받습니다.</p>
-                  </div>
-
-                  <div class="ai-response-toggle" style="opacity: 0.3">
-                    <img
-                      class="tiny-icons"
-                      th:src="@{/images/icons/icon-check-empty.png}"
-                      alt="check icon"
-                      data-checked-src="@{/images/icons/icon-check.png}"
-                      data-unchecked-src="@{/images/icons/icon-check-empty.png}"
-                    />
-                    <p>이 게시물에 대해 AI의 피드백을 받습니다.</p>
-                  </div>
-                </div>
-
-                <div class="post-button-container">
+              <div class="new-post-content-container">
+                <div class="new-post-content">
                   <img
+                      class="user-photo"
+                      th:src="@{${post.user.profileImage}}"
+                      alt="user icon"
+                  />
+                  <div class="new-post-text-container">
+                        <textarea
+                            name="content"
+                            id="new-post-content"
+                            class="new-post-text"
+                            th:text="${post.content}"
+                        ></textarea>
+                    <p class="letter-count" id="count500">500/500</p>
+                  </div>
+                </div>
+
+                <div class="manito-response-toggle">
+                  <img
+                      class="tiny-icons"
+                      th:src="@{/images/icons/icon-check-empty.png}"
+                      alt="check icon"
+                      data-checked-src="@{/images/icons/icon-check.png}"
+                      data-unchecked-src="@{/images/icons/icon-check-empty.png}"
+                  />
+                  <p>이 게시물에 대해 마니또의 답변을 받습니다.</p>
+                </div>
+
+                <div
+                    class="ai-response-toggle"
+                    onclick="toggleAI(this)"
+                    style="opacity: 0.3"
+                >
+                  <img
+                      class="tiny-icons"
+                      th:src="@{/images/icons/icon-check-empty.png}"
+                      alt="check icon"
+                      data-checked-src="@{/images/icons/icon-check.png}"
+                      data-unchecked-src="@{/images/icons/icon-check-empty.png}"
+                  />
+                  <p>이 게시물에 대해 AI의 피드백을 받습니다.</p>
+                </div>
+              </div>
+
+              <div class="post-button-container">
+                <input
+                    type="file"
+                    id="image-upload-btn"
+                    name="images"
+                    accept="image/jpeg, image/png"
+                    multiple
+                    onchange="countImages(this)"
+                    style="display: none"
+                />
+                <img
                     class="tiny-icons"
                     th:src="@{/images/icons/icon-image2.png}"
                     alt="add image icon"
-                  />
-                  <button
+                    onclick="document.getElementById('image-upload-btn').click()"
+                />
+                <button
                     class="post-button"
                     type="submit"
-                    th:onclick="'onNewReplySubmit(' + ${post.postId} + ')'"
-                  >
-                    작성하기
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            <!-- 답글 -->
-            <div class="post-container" th:each="reply : ${replies}">
-              <img
-                class="user-photo"
-                th:src="@{${reply.user.profileImage}}"
-                alt="user icon"
-              />
-              <div class="post-content">
-                <div class="user-info">
-                  <span
-                    class="user-name"
-                    th:text="${reply.user.nickname}"
-                  ></span>
-                  <span
-                    class="passed-time"
-                    th:text="${#temporals.format(reply.createdAt, 'mm분')}"
-                  ></span>
-                </div>
-                <p
-                  class="content-text"
-                  th:text="${reply.content}"
-                  th:onclick="'directToReply(' + ${reply.replyPostId} + ')'"
-                ></p>
-                <div class="reaction-icons">
-                  <img
-                    class="tiny-icons"
-                    th:src="@{/images/icons/icon-clover2.png}"
-                    alt="I like this"
-                    th:onclick="'likeReply(' + ${reply.replyPostId} + ')'"
-                  />
-                  <span
-                    class="like-count"
-                    th:text="${reply.likesNumber}"
-                  ></span>
-                  <img
-                    class="tiny-icons"
-                    th:src="@{/images/icons/icon-comment2.png}"
-                    alt="add reply"
-                  />
-                  <span
-                    class="reply-count"
-                    th:text="${reply.rerepliesNumber}"
-                  ></span>
-                </div>
-              </div>
-              <div class="option-icons">
-                <img
-                  class="tiny-icons"
-                  th:src="@{/images/icons/UI-more2.png}"
-                  alt="more options"
-                  th:onclick="'openReplyOptionsModal()'"
-                />
-                <img
-                  class="tiny-icons"
-                  th:if="${currentUser != reply.user && !#lists.contains(followings, reply.user)}"
-                  th:src="@{/images/icons/icon-add-friend.png}"
-                  alt="add friend"
-                />
-              </div>
-
-              <!-- 답글 추가 기능 모달 -->
-              <div
-                class="list-group post-options-modal"
-                id="reply-options-modal"
-                style="display: none"
-              >
-                <div class="options-modal-content">
-                  <button
-                    type="button"
-                    class="list-group-item list-group-item-action"
-                    aria-current="true"
-                    th:if="${currentUser == reply.user}"
-                    th:onclick="'openUpdateReplyModal()'"
-                  >
-                    수정하기
-                  </button>
-                  <button
-                    type="button"
-                    class="list-group-item list-group-item-action"
-                    th:if="${currentUser == reply.user}"
-                    th:onclick="'hideReply(' + ${reply.replyPostId} + ')'"
-                  >
-                    숨기기
-                  </button>
-                  <button
-                    type="button"
-                    class="list-group-item list-group-item-action"
-                    th:if="${currentUser == reply.user}"
-                    th:onclick="'deleteReply(' + ${reply.replyPostId} + ')'"
-                  >
-                    삭제하기
-                  </button>
-                  <button
-                    type="button"
-                    class="list-group-item list-group-item-action"
-                    th:onclick="'openReplyReportModal()'"
-                  >
-                    신고하기
-                  </button>
-                </div>
-              </div>
-
-              <!-- 답글 수정 모달 -->
-              <div class="new-post-form-modal" id="updateReplyFormModal">
-                <div
-                  class="new-post-form-modal-container"
-                  id="updateReplyFormModalContainer"
+                    th:onclick="'onUpdatePostSubmit(' + ${post.postId} + ')'"
                 >
-                  <div class="new-post-title">
-                    <p>답글 수정</p>
-                    <img
-                      class="tiny-icons"
-                      id="closeReplyFormModalBtn"
-                      th:src="@{/images/icons/icon-cancel.png}"
-                      alt="close icon"
-                      th:onclick="'closeUpdateReplyModal()'"
-                    />
-                  </div>
-
-                  <div class="new-post-content-container">
-                    <div class="new-post-content">
-                      <img
-                        class="user-photo"
-                        th:src="@{${reply.user.profileImage}}"
-                        alt="user icon"
-                      />
-                      <div class="new-post-text-container">
-                        <textarea
-                          name="content"
-                          id="update-reply-content"
-                          class="new-post-text"
-                          th:text="${reply.content}"
-                        ></textarea>
-                        <p class="letter-count" id="count-500">500/500</p>
-                      </div>
-                    </div>
-
-                    <div class="manito-response-toggle">
-                      <img
-                        class="tiny-icons"
-                        th:src="@{/images/icons/icon-check-empty.png}"
-                        alt="check icon"
-                        data-checked-src="@{/images/icons/icon-check.png}"
-                        data-unchecked-src="@{/images/icons/icon-check-empty.png}"
-                      />
-                      <p>이 게시물에 대해 마니또의 답변을 받습니다.</p>
-                    </div>
-
-                    <div
-                      class="ai-response-toggle"
-                      onclick="toggleAI(this)"
-                      style="opacity: 0.3"
-                    >
-                      <img
-                        class="tiny-icons"
-                        th:src="@{/images/icons/icon-check-empty.png}"
-                        alt="check icon"
-                        data-checked-src="@{/images/icons/icon-check.png}"
-                        data-unchecked-src="@{/images/icons/icon-check-empty.png}"
-                      />
-                      <p>이 게시물에 대해 AI의 피드백을 받습니다.</p>
-                    </div>
-                  </div>
-
-                  <div class="post-button-container">
-                    <img
-                      class="tiny-icons"
-                      th:src="@{/images/icons/icon-image2.png}"
-                      alt="add image icon"
-                    />
-                    <button
-                      class="post-button"
-                      type="submit"
-                      th:onclick="'onUpdateReplySubmit(' + ${reply.replyPostId} +')'"
-                    >
-                      수정하기
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <!-- 답글 신고 모달 -->
-              <div class="report-modal" id="replyReportModal">
-                <form
-                  class="report-modal-container"
-                  id="replyReportModalContainer"
-                  th:action="@{/api/reply/report/{replyId}(replyId=${reply.replyPostId})}"
-                  method="post"
-                  th:onsubmit="'onReplyReportSubmit(event)'"
-                >
-                  <div class="report-title">
-                    <p>신고하기</p>
-                    <img
-                      class="tiny-icons"
-                      id="closeReplyReportModalBtn"
-                      th:src="@{/images/icons/icon-cancel.png}"
-                      alt="close icon"
-                      th:onclick="'closeReplyReportModal()'"
-                    />
-                  </div>
-                  <div class="report-container">
-                    <label for="reply-report-type-select"
-                      >신고 사유를 선택해주세요</label
-                    >
-                    <select
-                      name="reportType"
-                      id="reply-report-type-select"
-                      class="report-type-select"
-                    >
-                      <option value="">신고 사유 선택</option>
-                      <option value="DISLIKE">마음에 들지 않습니다</option>
-                      <option value="HARASSMENT">
-                        따돌림 또는 원치 않은 연락
-                      </option>
-                      <option value="SELF_HARM">자살, 자해 및 섭식 장애</option>
-                      <option value="ABUSE">폭력, 혐오 또는 학대</option>
-                      <option value="RESTRICTED_ITEMS">
-                        제한된 품목을 판매하거나 홍보함
-                      </option>
-                      <option value="ADULT_CONTENT">
-                        나체 이미지 또는 성적 행위
-                      </option>
-                      <option value="SCAM">스캠, 사기 또는 스팸</option>
-                      <option value="MISINFO">거짓 정보</option>
-                    </select>
-                  </div>
-                  <div class="report-send-button-container">
-                    <button
-                      class="report-send-button"
-                      id="replyReportSendBtn"
-                      type="submit"
-                    >
-                      전송하기
-                    </button>
-                  </div>
-                </form>
+                  수정하기
+                </button>
               </div>
             </div>
           </div>
-        </section>
-      </section>
-      <article
-        th:replace="~{fragments/common/right-section :: right-section}"
-      ></article>
-    </main>
-    <!-- 게시글 추가 기능 모달 -->
-    <div
-        class="list-group post-options-modal"
-        id="post-options-modal"
-        style="display: none"
-    >
-      <div class="options-modal-content">
-        <button
-            type="button"
-            class="list-group-item list-group-item-action"
-            aria-current="true"
-            th:onclick="'openUpdatePostModal()'"
-        >
-          수정하기
-        </button>
-        <button
-            type="button"
-            class="list-group-item list-group-item-action"
-            th:onclick="'hidePost(' + ${post.postId} + ')'"
-        >
-          숨기기
-        </button>
-        <button
-            type="button"
-            class="list-group-item list-group-item-action"
-            th:onclick="'deletePost(' + ${post.postId} + ')'"
-        >
-          삭제하기
-        </button>
-        <button
-            type="button"
-            class="list-group-item list-group-item-action"
-            th:onclick="'openPostReportModal()'"
-        >
-          신고하기
-        </button>
+
+          <!-- 게시글 신고 모달 -->
+          <div class="report-modal" id="postReportModal">
+            <form
+                class="report-modal-container"
+                id="postReportModalContainer"
+                th:action="@{/api/post/report/{postId}(postId=${post.postId})}"
+                method="post"
+                th:onsubmit="'onPostReportSubmit(event)'"
+            >
+              <div class="report-title">
+                <p>신고하기</p>
+                <img
+                    class="tiny-icons"
+                    id="closePostReportModalBtn"
+                    th:src="@{/images/icons/icon-cancel.png}"
+                    alt="close icon"
+                    th:onclick="'closePostReportModal()'"
+                />
+              </div>
+              <div class="report-container">
+                <label for="post-report-type-select"
+                >신고 사유를 선택해주세요</label
+                >
+                <select
+                    name="reportType"
+                    id="post-report-type-select"
+                    class="report-type-select"
+                >
+                  <option value="">신고 사유 선택</option>
+                  <option value="DISLIKE">마음에 들지 않습니다</option>
+                  <option value="HARASSMENT">
+                    따돌림 또는 원치 않은 연락
+                  </option>
+                  <option value="SELF_HARM">자살, 자해 및 섭식 장애</option>
+                  <option value="ABUSE">폭력, 혐오 또는 학대</option>
+                  <option value="RESTRICTED_ITEMS">
+                    제한된 품목을 판매하거나 홍보함
+                  </option>
+                  <option value="ADULT_CONTENT">
+                    나체 이미지 또는 성적 행위
+                  </option>
+                  <option value="SCAM">스캠, 사기 또는 스팸</option>
+                  <option value="MISINFO">거짓 정보</option>
+                </select>
+              </div>
+              <div class="report-send-button-container">
+                <button
+                    class="report-send-button"
+                    id="postReportSendBtn"
+                    type="submit"
+                >
+                  전송하기
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <div id="reply-divider" th:onclick="'openNewReplyModal()'">
+          <p id="reply-divider-text">답글</p>
+        </div>
+
+        <!-- 답글 작성 모달 -->
+        <div class="new-post-form-modal" id="newReplyFormModal">
+          <div
+              class="new-post-form-modal-container"
+              id="newReplyFormModalContainer"
+          >
+            <div class="new-post-title">
+              <p>답글 작성</p>
+              <img
+                  class="tiny-icons"
+                  id="closeNewReplyFormModalBtn"
+                  th:src="@{/images/icons/icon-cancel.png}"
+                  alt="close icon"
+                  th:onclick="'closeNewReplyModal()'"
+              />
+            </div>
+
+            <div class="new-post-content-container">
+              <div class="new-post-content">
+                <img
+                    class="user-photo"
+                    th:src="@{${currentUser.profileImage}}"
+                    alt="user icon"
+                />
+                <div class="new-post-text-container">
+                      <textarea
+                          name="content"
+                          id="new-reply-content"
+                          class="new-post-text"
+                          placeholder="나누고 싶은 글을 작성해주세요"
+                      ></textarea>
+                  <p class="letter-count" id="countTo500">500/500</p>
+                </div>
+              </div>
+
+              <div class="manito-response-toggle">
+                <img
+                    class="tiny-icons"
+                    th:src="@{/images/icons/icon-check-empty.png}"
+                    alt="check icon"
+                    data-checked-src="@{/images/icons/icon-check.png}"
+                    data-unchecked-src="@{/images/icons/icon-check-empty.png}"
+                />
+                <p>이 게시물에 대해 마니또의 답변을 받습니다.</p>
+              </div>
+
+              <div class="ai-response-toggle" style="opacity: 0.3">
+                <img
+                    class="tiny-icons"
+                    th:src="@{/images/icons/icon-check-empty.png}"
+                    alt="check icon"
+                    data-checked-src="@{/images/icons/icon-check.png}"
+                    data-unchecked-src="@{/images/icons/icon-check-empty.png}"
+                />
+                <p>이 게시물에 대해 AI의 피드백을 받습니다.</p>
+              </div>
+            </div>
+
+            <div class="post-button-container">
+              <img
+                  class="tiny-icons"
+                  th:src="@{/images/icons/icon-image2.png}"
+                  alt="add image icon"
+              />
+              <button
+                  class="post-button"
+                  type="submit"
+                  th:onclick="'onNewReplySubmit(' + ${post.postId} + ')'"
+              >
+                작성하기
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- 답글 -->
+        <div class="post-container" th:each="reply : ${replies}">
+          <img
+              class="user-photo"
+              th:src="@{${reply.user.profileImage}}"
+              alt="user icon"
+          />
+          <div class="post-content">
+            <div class="user-info">
+                  <span
+                      class="user-name"
+                      th:text="${reply.user.nickname}"
+                  ></span>
+              <span
+                  class="passed-time"
+                  th:text="${#temporals.format(reply.createdAt, 'mm분')}"
+              ></span>
+            </div>
+            <p
+                class="content-text"
+                th:text="${reply.content}"
+                th:onclick="'directToReply(' + ${reply.replyPostId} + ')'"
+            ></p>
+            <div class="reaction-icons">
+              <img
+                  class="tiny-icons"
+                  th:src="@{/images/icons/icon-clover2.png}"
+                  alt="I like this"
+                  th:onclick="'likeReply(' + ${reply.replyPostId} + ')'"
+              />
+              <span
+                  class="like-count"
+                  th:text="${reply.likesNumber}"
+              ></span>
+              <img
+                  class="tiny-icons"
+                  th:src="@{/images/icons/icon-comment2.png}"
+                  alt="add reply"
+              />
+              <span
+                  class="reply-count"
+                  th:text="${reply.rerepliesNumber}"
+              ></span>
+            </div>
+          </div>
+          <div class="option-icons">
+            <img
+                class="tiny-icons"
+                th:src="@{/images/icons/UI-more2.png}"
+                alt="more options"
+                th:onclick="'openReplyOptionsModal()'"
+            />
+            <img
+                class="tiny-icons"
+                th:if="${currentUser != reply.user && !#lists.contains(followings, reply.user)}"
+                th:src="@{/images/icons/icon-add-friend.png}"
+                alt="add friend"
+            />
+          </div>
+
+          <!-- 답글 추가 기능 모달 -->
+          <div
+              class="list-group post-options-modal"
+              id="reply-options-modal"
+              style="display: none"
+          >
+            <div class="options-modal-content">
+              <button
+                  type="button"
+                  class="list-group-item list-group-item-action"
+                  aria-current="true"
+                  th:if="${currentUser == reply.user}"
+                  th:onclick="'openUpdateReplyModal()'"
+              >
+                수정하기
+              </button>
+              <button
+                  type="button"
+                  class="list-group-item list-group-item-action"
+                  th:if="${currentUser == reply.user}"
+                  th:onclick="'hideReply(' + ${reply.replyPostId} + ')'"
+              >
+                숨기기
+              </button>
+              <button
+                  type="button"
+                  class="list-group-item list-group-item-action"
+                  th:if="${currentUser == reply.user}"
+                  th:onclick="'deleteReply(' + ${reply.replyPostId} + ')'"
+              >
+                삭제하기
+              </button>
+              <button
+                  type="button"
+                  class="list-group-item list-group-item-action"
+                  th:onclick="'openReplyReportModal()'"
+              >
+                신고하기
+              </button>
+            </div>
+          </div>
+
+          <!-- 답글 수정 모달 -->
+          <div class="new-post-form-modal" id="updateReplyFormModal">
+            <div
+                class="new-post-form-modal-container"
+                id="updateReplyFormModalContainer"
+            >
+              <div class="new-post-title">
+                <p>답글 수정</p>
+                <img
+                    class="tiny-icons"
+                    id="closeReplyFormModalBtn"
+                    th:src="@{/images/icons/icon-cancel.png}"
+                    alt="close icon"
+                    th:onclick="'closeUpdateReplyModal()'"
+                />
+              </div>
+
+              <div class="new-post-content-container">
+                <div class="new-post-content">
+                  <img
+                      class="user-photo"
+                      th:src="@{${reply.user.profileImage}}"
+                      alt="user icon"
+                  />
+                  <div class="new-post-text-container">
+                        <textarea
+                            name="content"
+                            id="update-reply-content"
+                            class="new-post-text"
+                            th:text="${reply.content}"
+                        ></textarea>
+                    <p class="letter-count" id="count-500">500/500</p>
+                  </div>
+                </div>
+
+                <div class="manito-response-toggle">
+                  <img
+                      class="tiny-icons"
+                      th:src="@{/images/icons/icon-check-empty.png}"
+                      alt="check icon"
+                      data-checked-src="@{/images/icons/icon-check.png}"
+                      data-unchecked-src="@{/images/icons/icon-check-empty.png}"
+                  />
+                  <p>이 게시물에 대해 마니또의 답변을 받습니다.</p>
+                </div>
+
+                <div
+                    class="ai-response-toggle"
+                    onclick="toggleAI(this)"
+                    style="opacity: 0.3"
+                >
+                  <img
+                      class="tiny-icons"
+                      th:src="@{/images/icons/icon-check-empty.png}"
+                      alt="check icon"
+                      data-checked-src="@{/images/icons/icon-check.png}"
+                      data-unchecked-src="@{/images/icons/icon-check-empty.png}"
+                  />
+                  <p>이 게시물에 대해 AI의 피드백을 받습니다.</p>
+                </div>
+              </div>
+
+              <div class="post-button-container">
+                <img
+                    class="tiny-icons"
+                    th:src="@{/images/icons/icon-image2.png}"
+                    alt="add image icon"
+                />
+                <button
+                    class="post-button"
+                    type="submit"
+                    th:onclick="'onUpdateReplySubmit(' + ${reply.replyPostId} +')'"
+                >
+                  수정하기
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- 답글 신고 모달 -->
+          <div class="report-modal" id="replyReportModal">
+            <form
+                class="report-modal-container"
+                id="replyReportModalContainer"
+                th:action="@{/api/reply/report/{replyId}(replyId=${reply.replyPostId})}"
+                method="post"
+                th:onsubmit="'onReplyReportSubmit(event)'"
+            >
+              <div class="report-title">
+                <p>신고하기</p>
+                <img
+                    class="tiny-icons"
+                    id="closeReplyReportModalBtn"
+                    th:src="@{/images/icons/icon-cancel.png}"
+                    alt="close icon"
+                    th:onclick="'closeReplyReportModal()'"
+                />
+              </div>
+              <div class="report-container">
+                <label for="reply-report-type-select"
+                >신고 사유를 선택해주세요</label
+                >
+                <select
+                    name="reportType"
+                    id="reply-report-type-select"
+                    class="report-type-select"
+                >
+                  <option value="">신고 사유 선택</option>
+                  <option value="DISLIKE">마음에 들지 않습니다</option>
+                  <option value="HARASSMENT">
+                    따돌림 또는 원치 않은 연락
+                  </option>
+                  <option value="SELF_HARM">자살, 자해 및 섭식 장애</option>
+                  <option value="ABUSE">폭력, 혐오 또는 학대</option>
+                  <option value="RESTRICTED_ITEMS">
+                    제한된 품목을 판매하거나 홍보함
+                  </option>
+                  <option value="ADULT_CONTENT">
+                    나체 이미지 또는 성적 행위
+                  </option>
+                  <option value="SCAM">스캠, 사기 또는 스팸</option>
+                  <option value="MISINFO">거짓 정보</option>
+                </select>
+              </div>
+              <div class="report-send-button-container">
+                <button
+                    class="report-send-button"
+                    id="replyReportSendBtn"
+                    type="submit"
+                >
+                  전송하기
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
       </div>
-    </div>
-    <script th:src="@{/script/common.js}"></script>
-    <script th:src="@{/script/post.js}"></script>
-  </body>
+    </section>
+  </section>
+  <article
+      th:replace="~{fragments/common/right-section :: right-section}"
+  ></article>
+</main>
+<!-- 게시글 추가 기능 모달 -->
+<div
+    class="list-group post-options-modal"
+    id="post-options-modal"
+    style="display: none"
+>
+  <div class="options-modal-content">
+    <button
+        type="button"
+        class="list-group-item list-group-item-action"
+        aria-current="true"
+        th:onclick="'openUpdatePostModal()'"
+    >
+      수정하기
+    </button>
+    <button
+        type="button"
+        class="list-group-item list-group-item-action"
+        th:onclick="'hidePost(' + ${post.postId} + ')'"
+    >
+      숨기기
+    </button>
+    <button
+        type="button"
+        class="list-group-item list-group-item-action"
+        th:onclick="'deletePost(' + ${post.postId} + ')'"
+    >
+      삭제하기
+    </button>
+    <button
+        type="button"
+        class="list-group-item list-group-item-action"
+        th:onclick="'openPostReportModal()'"
+    >
+      신고하기
+    </button>
+  </div>
+</div>
+<script th:src="@{/script/common.js}"></script>
+<script th:src="@{/script/post.js}"></script>
+</body>
 </html>


### PR DESCRIPTION
## :mag_right: 작업 내용

- 타임라인에서 사진 표시
- 마니또 편지 클릭시 원 게시글 상세페이지로 이동
- 게시글 상세 페이지 뒤로 가기 버튼 추가
- 
## ⚫️이미지 첨부
<br/>


## :heavy_plus_sign: 이슈 링크

- [#이슈번호](이슈 주소)
