### PR TITLE
좋아요 누른 게시글의 프로필 이미지가 내 이미지로 나오던 문제 수정

### DIFF
--- a/src/main/java/com/finalproject/manitoone/service/PostService.java
+++ b/src/main/java/com/finalproject/manitoone/service/PostService.java
@@ -433,7 +433,7 @@ public class PostService {
         .stream()
         .map(userPostLike -> new PostViewResponseDto(
             userPostLike.getPost().getPostId(),
-            userPostLike.getUser().getProfileImage(),
+            userPostLike.getPost().getUser().getProfileImage(),
             userPostLike.getPost().getUser().getNickname(),
             userPostLike.getPost().getContent(),
             userPostLike.getPost().getCreatedAt(),


### PR DESCRIPTION
## :mag_right: 작업 내용
- 좋아요 누른 게시글의 프로필 이미지가 내 이미지로 나오던 문제를 수정 하였습니다.


## ⚫️이미지 첨부

|수정 전|수정 후|
|---|---|
|![image](https://github.com/user-attachments/assets/d11f7f16-95f8-462f-8181-253b2296c8e5)|![image](https://github.com/user-attachments/assets/18afe7ae-7cf6-460e-8764-7b0f7121dbfa)|
## :heavy_plus_sign: 이슈 링크

